### PR TITLE
Add MAC address attribute to Port create

### DIFF
--- a/nautobot_ssot_aristacv/diffsync/models/nautobot.py
+++ b/nautobot_ssot_aristacv/diffsync/models/nautobot.py
@@ -96,6 +96,7 @@ class NautobotPort(Port):
             name=ids["name"],
             device=device,
             enabled=is_truthy(attrs["enabled"]),
+            mac_address=attrs["mac_addr"],
             mtu=attrs["mtu"],
             mode=attrs["mode"],
             status=OrmStatus.objects.get(slug=attrs["status"]),


### PR DESCRIPTION
It appears I accidentally forgot to set the MAC address on a Port when it was created. This fixes that oversight.