### PR TITLE
Add support for Device Lifecycle Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ A plugin for [Nautobot](https://github.com/nautobot/nautobot) that allows synchr
 | bgp                     | bgp                          |
 | terminattr              | TerminAttr Version           |
 | ztp                     | ztp                          |
-| eos                     | EOS Version                  |
+| eos                     | EOS Version**                |
 | topology_type           | Topology Type                |
-> The model system tag is mapped to the device type model in Nautobot.
+> *The model system tag is mapped to the device type model in Nautobot.
+
+> **If the [Device Lifecycle plug-in](https://github.com/nautobot/nautobot-plugin-device-lifecycle-mgmt) is found to be installed, a matching Version will be created with a RelationshipAssociation connecting the device and that Version.
 
 When syncing User tags from Nautobot to CloudVision the data mappings are as follows:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A plugin for [Nautobot](https://github.com/nautobot/nautobot) that allows synchr
 | topology_network_type   | Topology Network Type        |
 | mlag                    | mlag                         |
 | mpls                    | mpls                         |
-| model                   | Device Platform*             |
+| model                   | Device Type*                 |
 | systype                 | systype                      |
 | serialnumber            | Device Serial Number         |
 | pimbidir                | pimbidir                     |
@@ -20,7 +20,7 @@ A plugin for [Nautobot](https://github.com/nautobot/nautobot) that allows synchr
 | ztp                     | ztp                          |
 | eos                     | EOS Version                  |
 | topology_type           | Topology Type                |
-> The model system tag is mapped to the device platform model in Nautobot.
+> The model system tag is mapped to the device type model in Nautobot.
 
 When syncing User tags from Nautobot to CloudVision the data mappings are as follows:
 

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -9,10 +9,10 @@ WORKDIR /source
 COPY poetry.lock pyproject.toml /source/
 # --no-root declares not to install the project package since we're wanting to take advantage of caching dependency installation
 # and the project is copied in and installed after this step
-RUN poetry install --no-interaction --no-ansi --no-root
+RUN poetry install --no-interaction --no-ansi --no-root --extras "nautobot-device-lifecycle-mgmt"
 
 # Copy in the rest of the source code and install local Nautobot plugin
 COPY . /source
-RUN poetry install --no-interaction --no-ansi --no-root --extras "nautobot-device-lifecycle-mgmt"
+RUN poetry install --no-interaction --no-ansi
 
 COPY development/nautobot_config.py /opt/nautobot/nautobot_config.py

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -13,6 +13,6 @@ RUN poetry install --no-interaction --no-ansi --no-root
 
 # Copy in the rest of the source code and install local Nautobot plugin
 COPY . /source
-RUN poetry install --no-interaction --no-ansi
+RUN poetry install --no-interaction --no-ansi --no-root --extras "nautobot-device-lifecycle-mgmt"
 
 COPY development/nautobot_config.py /opt/nautobot/nautobot_config.py

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -62,7 +62,7 @@ CACHEOPS_REDIS = parse_redis_connection(redis_database=1)
 SECRET_KEY = os.getenv("NAUTOBOT_SECRET_KEY", "")
 
 # Enable installed plugins. Add the name of each plugin to the list.
-PLUGINS = ["nautobot_ssot", "nautobot_ssot_aristacv"]
+PLUGINS = ["nautobot_ssot", "nautobot_ssot_aristacv", "nautobot_device_lifecycle_mgmt"]
 
 # Plugins configuration settings. These settings are used by various plugins that the user may have installed.
 # Each key in the dictionary is the name of an installed plugin and its value is a dictionary of settings.

--- a/nautobot_ssot_aristacv/__init__.py
+++ b/nautobot_ssot_aristacv/__init__.py
@@ -41,9 +41,13 @@ class NautobotSSOTAristaCVConfig(PluginConfig):
 
         from .signals import (  # pylint: disable=import-outside-toplevel
             post_migrate_create_custom_fields,
+            post_migrate_create_manufacturer,
+            post_migrate_create_platform,
         )
 
         post_migrate.connect(post_migrate_create_custom_fields)
+        post_migrate.connect(post_migrate_create_manufacturer)
+        post_migrate.connect(post_migrate_create_platform)
 
 
 config = NautobotSSOTAristaCVConfig  # pylint:disable=invalid-name

--- a/nautobot_ssot_aristacv/diffsync/adapters/cloudvision.py
+++ b/nautobot_ssot_aristacv/diffsync/adapters/cloudvision.py
@@ -33,7 +33,11 @@ class CloudvisionAdapter(DiffSync):
         for dev in cloudvision.get_devices(client=self.conn.comm_channel):
             if dev["hostname"] != "":
                 new_device = self.device(
-                    name=dev["hostname"], serial=dev["device_id"], device_model=dev["model"], uuid=None
+                    name=dev["hostname"],
+                    serial=dev["device_id"],
+                    device_model=dev["model"],
+                    version=dev["sw_ver"],
+                    uuid=None,
                 )
                 try:
                     self.add(new_device)

--- a/nautobot_ssot_aristacv/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot_aristacv/diffsync/adapters/nautobot.py
@@ -39,7 +39,7 @@ class NautobotAdapter(DiffSync):
                 continue
 
             for cf_name, cf_value in dev.custom_field_data.items():
-                if cf_name.starts_with("arista_"):
+                if cf_name.startswith("arista_"):
                     try:
                         new_cf = self.cf(
                             name=cf_name, value=cf_value if cf_value is not None else "", device_name=dev.name

--- a/nautobot_ssot_aristacv/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot_aristacv/diffsync/adapters/nautobot.py
@@ -28,7 +28,7 @@ class NautobotAdapter(DiffSync):
             try:
                 new_device = self.device(
                     name=dev.name,
-                    device_model=dev.device_type.name,
+                    device_model=dev.device_type.model,
                     serial=dev.serial,
                     version=nautobot.get_device_version(dev),
                     uuid=dev.id,
@@ -50,7 +50,7 @@ class NautobotAdapter(DiffSync):
                         continue
 
                 # Gets model from device type and puts it into CustomField Object.
-                new_cf = self.cf(name="arista_model", value=str(dev.device_type.name), device_name=dev.name)
+                new_cf = self.cf(name="arista_model", value=str(dev.device_type.model), device_name=dev.name)
                 self.add(new_cf)
 
         for intf in OrmInterface.objects.all():

--- a/nautobot_ssot_aristacv/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot_aristacv/diffsync/adapters/nautobot.py
@@ -49,10 +49,6 @@ class NautobotAdapter(DiffSync):
                         self.job.log_warning(message=f"Unable to load {cf_name}. {err}")
                         continue
 
-            # Gets model from device type and puts it into CustomField Object.
-            new_cf = self.cf(name="arista_model", value=str(dev.device_type.model), device_name=dev.name)
-            self.add(new_cf)
-
         for intf in OrmInterface.objects.all():
             new_port = self.port(
                 name=intf.name,

--- a/nautobot_ssot_aristacv/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot_aristacv/diffsync/adapters/nautobot.py
@@ -5,6 +5,7 @@ from diffsync import DiffSync
 from diffsync.exceptions import ObjectNotFound
 
 from nautobot_ssot_aristacv.diffsync.models.nautobot import NautobotDevice, NautobotCustomField, NautobotPort
+from nautobot_ssot_aristacv.utils import nautobot
 
 
 class NautobotAdapter(DiffSync):
@@ -28,7 +29,11 @@ class NautobotAdapter(DiffSync):
             try:
                 if dev.device_type.manufacturer.name.lower() == "arista":
                     new_device = self.device(
-                        name=dev.name, device_model=dev.device_type.name, serial=dev.serial, uuid=dev.id
+                        name=dev.name,
+                        device_model=dev.device_type.name,
+                        serial=dev.serial,
+                        version=nautobot.get_device_version(dev),
+                        uuid=dev.id,
                     )
                     self.add(new_device)
                     dev_custom_fields = dev.custom_field_data

--- a/nautobot_ssot_aristacv/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot_aristacv/diffsync/adapters/nautobot.py
@@ -55,7 +55,7 @@ class NautobotAdapter(DiffSync):
                 name=intf.name,
                 device=intf.device.name,
                 description=intf.description,
-                mac_addr=intf.mac_address if intf.mac_address else "",
+                mac_addr=str(intf.mac_address) if intf.mac_address else "",
                 enabled=intf.enabled,
                 mode=intf.mode,
                 mtu=intf.mtu,

--- a/nautobot_ssot_aristacv/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot_aristacv/diffsync/adapters/nautobot.py
@@ -2,7 +2,7 @@
 from nautobot.dcim.models import Device as OrmDevice
 from nautobot.dcim.models import Interface as OrmInterface
 from diffsync import DiffSync
-from diffsync.exceptions import ObjectNotFound
+from diffsync.exceptions import ObjectNotFound, ObjectAlreadyExists
 
 from nautobot_ssot_aristacv.diffsync.models.nautobot import NautobotDevice, NautobotCustomField, NautobotPort
 from nautobot_ssot_aristacv.utils import nautobot
@@ -24,31 +24,34 @@ class NautobotAdapter(DiffSync):
 
     def load(self):
         """Load device custom field data from Nautobot and populate DiffSync models."""
-        devices = OrmDevice.objects.all()
-        for dev in devices:
+        for dev in OrmDevice.objects.filter(device_type__manufacturer__slug="arista"):
             try:
-                if dev.device_type.manufacturer.name.lower() == "arista":
-                    new_device = self.device(
-                        name=dev.name,
-                        device_model=dev.device_type.name,
-                        serial=dev.serial,
-                        version=nautobot.get_device_version(dev),
-                        uuid=dev.id,
-                    )
-                    self.add(new_device)
-                    dev_custom_fields = dev.custom_field_data
-
-                    for cf_name, cf_value in dev_custom_fields.items():
-                        if cf_value is None:
-                            cf_value = ""
-                        new_cf = self.cf(name=cf_name, value=cf_value, device_name=dev.name)
-                        self.add(new_cf)
-
-                    # Gets model from device and puts it into CustomField Object.
-                    new_cf = self.cf(name="arista_model", value=str(dev.platform), device_name=dev.name)
-                    self.add(new_cf)
-            except AttributeError:
+                new_device = self.device(
+                    name=dev.name,
+                    device_model=dev.device_type.name,
+                    serial=dev.serial,
+                    version=nautobot.get_device_version(dev),
+                    uuid=dev.id,
+                )
+                self.add(new_device)
+            except ObjectAlreadyExists as err:
+                self.job.log_warning(message=f"Unable to load {dev.name} as it appears to be a duplicate. {err}")
                 continue
+
+            for cf_name, cf_value in dev.custom_field_data.items():
+                if cf_name.starts_with("arista_"):
+                    try:
+                        new_cf = self.cf(
+                            name=cf_name, value=cf_value if cf_value is not None else "", device_name=dev.name
+                        )
+                        self.add(new_cf)
+                    except AttributeError as err:
+                        self.job.log_warning(message=f"Unable to load {cf_name}. {err}")
+                        continue
+
+                # Gets model from device type and puts it into CustomField Object.
+                new_cf = self.cf(name="arista_model", value=str(dev.device_type.name), device_name=dev.name)
+                self.add(new_cf)
 
         for intf in OrmInterface.objects.all():
             new_port = self.port(

--- a/nautobot_ssot_aristacv/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot_aristacv/diffsync/adapters/nautobot.py
@@ -49,9 +49,9 @@ class NautobotAdapter(DiffSync):
                         self.job.log_warning(message=f"Unable to load {cf_name}. {err}")
                         continue
 
-                # Gets model from device type and puts it into CustomField Object.
-                new_cf = self.cf(name="arista_model", value=str(dev.device_type.model), device_name=dev.name)
-                self.add(new_cf)
+            # Gets model from device type and puts it into CustomField Object.
+            new_cf = self.cf(name="arista_model", value=str(dev.device_type.model), device_name=dev.name)
+            self.add(new_cf)
 
         for intf in OrmInterface.objects.all():
             new_port = self.port(

--- a/nautobot_ssot_aristacv/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot_aristacv/diffsync/adapters/nautobot.py
@@ -54,7 +54,7 @@ class NautobotAdapter(DiffSync):
                 name=intf.name,
                 device=intf.device.name,
                 description=intf.description,
-                mac_addr=str(intf.mac_address) if intf.mac_address else "",
+                mac_addr=str(intf.mac_address).lower() if intf.mac_address else "",
                 enabled=intf.enabled,
                 mode=intf.mode,
                 mtu=intf.mtu,

--- a/nautobot_ssot_aristacv/diffsync/models/base.py
+++ b/nautobot_ssot_aristacv/diffsync/models/base.py
@@ -12,12 +12,14 @@ class Device(DiffSyncModel):
     _attributes = (
         "device_model",
         "serial",
+        "version",
     )
     _children = {"port": "ports"}
 
     name: str
     device_model: str
     serial: str
+    version: Optional[str]
     ports: List["Port"] = list()
     uuid: Optional[UUID]
 

--- a/nautobot_ssot_aristacv/diffsync/models/nautobot.py
+++ b/nautobot_ssot_aristacv/diffsync/models/nautobot.py
@@ -111,7 +111,6 @@ class NautobotDevice(Device):
         except SoftwareLCM.DoesNotExist:
             os_ver = SoftwareLCM(
                 device_platform=_platform,
-                manufacturer=nautobot.verify_manufacturer(),
                 version=version,
             )
             os_ver.validated_save()

--- a/nautobot_ssot_aristacv/diffsync/models/nautobot.py
+++ b/nautobot_ssot_aristacv/diffsync/models/nautobot.py
@@ -107,7 +107,7 @@ class NautobotDevice(Device):
         """Add OS Version as SoftwareLCM if Device Lifecycle Plugin found."""
         _platform = OrmPlatform.objects.get(slug="arista_eos")
         try:
-            os_ver = SoftwareLCM.objects.get(platform=_platform, version=version)
+            os_ver = SoftwareLCM.objects.get(device_platform=_platform, version=version)
         except SoftwareLCM.DoesNotExist:
             os_ver = SoftwareLCM(
                 device_platform=_platform,

--- a/nautobot_ssot_aristacv/diffsync/models/nautobot.py
+++ b/nautobot_ssot_aristacv/diffsync/models/nautobot.py
@@ -47,6 +47,7 @@ class NautobotDevice(Device):
             status=device_status,
             device_type=device_type_object,
             device_role=device_role_object,
+            platform=OrmPlatform.objects.get(slug="arista_eos"),
             site=default_site_object,
             name=ids["name"],
             serial=attrs["serial"] if attrs.get("serial") else "",
@@ -156,23 +157,6 @@ class NautobotCustomField(CustomField):
     @classmethod
     def create(cls, diffsync, ids, attrs):
         """Create Custom Field in Nautobot."""
-        if ids["name"] == "arista_model":
-            try:
-                # Try to create new platform
-                new_platform = OrmPlatform(name=attrs["value"], slug=attrs["value"].lower())
-                new_platform.validated_save()
-                # Assign new platform to device.
-                device = OrmDevice.objects.get(name=ids["device_name"])
-                device.platform = new_platform
-                device.validated_save()
-                return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
-            except ValidationError:
-                # Assign existing platform to device.
-                existing_platform = OrmPlatform.objects.get(name=attrs["value"])
-                device = OrmDevice.objects.get(name=ids["device_name"])
-                device.platform = existing_platform
-                device.validated_save()
-                return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
         try:
             attrs["value"] = bool(distutils.util.strtobool(attrs["value"]))
         except ValueError:
@@ -193,23 +177,6 @@ class NautobotCustomField(CustomField):
 
     def update(self, attrs):
         """Update Custom Field in Nautobot."""
-        if self.name == "arista_model":
-            try:
-                # Try to create new platform
-                new_platform = OrmPlatform(name=attrs["value"], slug=attrs["value"].lower())
-                new_platform.validated_save()
-                # Assign new platform to device.
-                device = OrmDevice.objects.get(name=self.device_name)
-                device.platform = new_platform
-                device.validated_save()
-                return super().update(attrs)
-            except ValidationError:
-                # Assign existing platform to device.
-                existing_platform = OrmPlatform.objects.get(name=attrs["value"])
-                device = OrmDevice.objects.get(name=self.device_name)
-                device.platform = existing_platform
-                device.validated_save()
-                return super().update(attrs)
         try:
             attrs["value"] = bool(distutils.util.strtobool(attrs["value"]))
         except ValueError:

--- a/nautobot_ssot_aristacv/diffsync/models/nautobot.py
+++ b/nautobot_ssot_aristacv/diffsync/models/nautobot.py
@@ -111,6 +111,7 @@ class NautobotDevice(Device):
         except SoftwareLCM.DoesNotExist:
             os_ver = SoftwareLCM(
                 device_platform=_platform,
+                manufacturer=nautobot.verify_manufacturer(),
                 version=version,
             )
             os_ver.validated_save()

--- a/nautobot_ssot_aristacv/diffsync/models/nautobot.py
+++ b/nautobot_ssot_aristacv/diffsync/models/nautobot.py
@@ -1,14 +1,25 @@
 """Nautobot DiffSync models for AristaCV SSoT."""
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.conf import settings
 from nautobot.core.settings_funcs import is_truthy
 from nautobot.dcim.models import Device as OrmDevice
 from nautobot.dcim.models import Interface as OrmInterface
 from nautobot.dcim.models import Platform as OrmPlatform
+from nautobot.extras.models import Relationship as OrmRelationship
+from nautobot.extras.models import RelationshipAssociation as OrmRelationshipAssociation
 from nautobot.extras.models import Status as OrmStatus
 from nautobot_ssot_aristacv.diffsync.models.base import Device, CustomField, Port
 from nautobot_ssot_aristacv.utils import nautobot
 import distutils
+
+try:
+    from nautobot_device_lifecycle_mgmt.models import SoftwareLCM
+
+    LIFECYCLE_MGMT = True
+except ImportError:
+    print("Device Lifecycle plugin isn't installed so will revert to CustomField for OS version.")
+    LIFECYCLE_MGMT = False
 
 
 DEFAULT_SITE = "cloudvision_imported"
@@ -57,6 +68,9 @@ class NautobotDevice(Device):
             new_device.tags.add(import_tag)
         try:
             new_device.validated_save()
+            if LIFECYCLE_MGMT and attrs.get("version"):
+                software_lcm = cls._add_software_lcm(version=attrs["version"])
+                cls._assign_version_to_device(diffsync=diffsync, device=new_device, software_lcm=software_lcm)
             return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
         except ValidationError as err:
             diffsync.job.log_warning(message=f"Unable to create Device {ids['name']}. {err}")
@@ -69,6 +83,9 @@ class NautobotDevice(Device):
             dev.device_type = nautobot.verify_device_type_object(attrs["device_model"])
         if "serial" in attrs:
             dev.serial = attrs["serial"]
+        if "version" in attrs and LIFECYCLE_MGMT:
+            software_lcm = self._add_software_lcm(version=attrs["version"])
+            self._assign_version_to_device(diffsync=self.diffsync, device=dev, software_lcm=software_lcm)
         try:
             dev.validated_save()
             return super().update(attrs)
@@ -84,6 +101,43 @@ class NautobotDevice(Device):
             device.delete()
             super().delete()
         return self
+
+    @staticmethod
+    def _add_software_lcm(version: str):
+        """Add OS Version as SoftwareLCM if Device Lifecycle Plugin found."""
+        _platform = OrmPlatform.objects.get(slug="arista_eos")
+        try:
+            os_ver = SoftwareLCM.objects.get(platform=_platform, version=version)
+        except SoftwareLCM.DoesNotExist:
+            os_ver = SoftwareLCM(
+                device_platform=_platform,
+                version=version,
+            )
+            os_ver.validated_save()
+        return os_ver
+
+    @staticmethod
+    def _assign_version_to_device(diffsync, device, software_lcm):
+        """Add Relationship between Device and SoftwareLCM."""
+        software_relation = OrmRelationship.objects.get(name="Software on Device")
+        relations = device.get_relationships()
+        for _, relationships in relations.items():
+            for relationship, queryset in relationships.items():
+                if relationship.id == software_relation:
+                    if diffsync.job.kwargs.get("debug"):
+                        diffsync.job.log_warning(
+                            message=f"Deleting Software Version Relationships for {device.name} to assign a new version."
+                        )
+                    queryset.delete()
+
+        new_assoc = OrmRelationshipAssociation(
+            relationship=software_relation,
+            source_type=ContentType.objects.get_for_model(SoftwareLCM),
+            source=software_lcm,
+            destination_type=ContentType.objects.get_for_model(OrmDevice),
+            destination=device,
+        )
+        new_assoc.validated_save()
 
 
 class NautobotPort(Port):

--- a/nautobot_ssot_aristacv/diffsync/models/nautobot.py
+++ b/nautobot_ssot_aristacv/diffsync/models/nautobot.py
@@ -245,10 +245,7 @@ class NautobotCustomField(CustomField):
         """Delete Custom Field in Nautobot."""
         try:
             device = OrmDevice.objects.get(name=self.device_name)
-            if self.name == "arista_model":
-                device.platform = None
-            else:
-                device.custom_field_data.update({self.name: None})
+            device.custom_field_data.update({self.name: None})
             device.validated_save()
             super().delete()
             return self

--- a/nautobot_ssot_aristacv/jobs.py
+++ b/nautobot_ssot_aristacv/jobs.py
@@ -96,7 +96,7 @@ class CloudVisionDataSource(DataSource, Job):  # pylint: disable=abstract-method
             DataMapping("topology_network_type", None, "Topology Network Type", None),
             DataMapping("mlag", None, "MLAG", None),
             DataMapping("mpls", None, "mpls", None),
-            DataMapping("model", None, "Device Type", get_route_for_model(DeviceType, "list")),
+            DataMapping("model", None, "Device Type", reverse(get_route_for_model(DeviceType, "list"))),
             DataMapping("systype", None, "systype", None),
             DataMapping("serialnumber", None, "Device Serial Number", None),
             DataMapping("pimbidir", None, "pimbidir", None),

--- a/nautobot_ssot_aristacv/jobs.py
+++ b/nautobot_ssot_aristacv/jobs.py
@@ -6,10 +6,11 @@ from django.conf import settings
 from django.templatetags.static import static
 from django.urls import reverse
 
+from nautobot.dcim.models import DeviceType
 from nautobot.extras.jobs import Job, BooleanVar
 from nautobot.extras.models.tags import Tag
 from nautobot.extras.models.customfields import CustomField
-
+from nautobot.utilities.utils import get_route_for_model
 from nautobot_ssot.jobs.base import DataTarget, DataSource, DataMapping
 
 from nautobot_ssot_aristacv.diffsync.adapters.cloudvision import CloudvisionAdapter
@@ -95,7 +96,7 @@ class CloudVisionDataSource(DataSource, Job):  # pylint: disable=abstract-method
             DataMapping("topology_network_type", None, "Topology Network Type", None),
             DataMapping("mlag", None, "MLAG", None),
             DataMapping("mpls", None, "mpls", None),
-            DataMapping("model", None, "Platform", reverse("dcim:platform_list")),
+            DataMapping("model", None, "Device Type", get_route_for_model(DeviceType, "list")),
             DataMapping("systype", None, "systype", None),
             DataMapping("serialnumber", None, "Device Serial Number", None),
             DataMapping("pimbidir", None, "pimbidir", None),

--- a/nautobot_ssot_aristacv/signals.py
+++ b/nautobot_ssot_aristacv/signals.py
@@ -82,11 +82,20 @@ def post_migrate_create_custom_fields(apps=global_apps, **kwargs):
         field, _ = CustomField.objects.get_or_create(name=device_cf_dict["name"], defaults=device_cf_dict)
         field.content_types.set([ContentType.objects.get_for_model(Device)])
 
-    # Ensure that the Arista Manufacturer and Platform has been created for assignment to Devices and with DLC plug-in integration
-    Manufacturer = apps.get_model("dcim", "Manufacturer")
-    arista_manu = Manufacturer.objects.get_or_create(name="Arista", slug="arista")
 
+def post_migrate_create_manufacturer(apps=global_apps, **kwargs):
+    """Callback function for post_migrate() -- create Arista Manufacturer."""
+    Manufacturer = apps.get_model("dcim", "Manufacturer")
+    Manufacturer.objects.get_or_create(name="Arista", slug="arista")
+
+
+def post_migrate_create_platform(apps=global_apps, **kwargs):
+    """Callback function for post_migrate() -- create Arista Platform."""
     Platform = apps.get_model("dcim", "Platform")
+    Manufacturer = apps.get_model("dcim", "Manufacturer")
     Platform.objects.get_or_create(
-        name="arista.eos.eos", slug="arista_eos", napalm_driver="eos", manufacturer=arista_manu
+        name="arista.eos.eos",
+        slug="arista_eos",
+        napalm_driver="eos",
+        manufacturer=Manufacturer.objects.get(slug="arista"),
     )

--- a/nautobot_ssot_aristacv/signals.py
+++ b/nautobot_ssot_aristacv/signals.py
@@ -81,3 +81,7 @@ def post_migrate_create_custom_fields(apps=global_apps, **kwargs):
     ]:
         field, _ = CustomField.objects.get_or_create(name=device_cf_dict["name"], defaults=device_cf_dict)
         field.content_types.set([ContentType.objects.get_for_model(Device)])
+
+    # Ensure that the Arista Platform has been created for assignment to Devices and with DLC plug-in integration
+    Platform = apps.get_model("dcim", "Platform")
+    Platform.objects.get_or_create(name="arista.eos.eos", slug="arista_eos", napalm_driver="eos")

--- a/nautobot_ssot_aristacv/signals.py
+++ b/nautobot_ssot_aristacv/signals.py
@@ -82,6 +82,11 @@ def post_migrate_create_custom_fields(apps=global_apps, **kwargs):
         field, _ = CustomField.objects.get_or_create(name=device_cf_dict["name"], defaults=device_cf_dict)
         field.content_types.set([ContentType.objects.get_for_model(Device)])
 
-    # Ensure that the Arista Platform has been created for assignment to Devices and with DLC plug-in integration
+    # Ensure that the Arista Manufacturer and Platform has been created for assignment to Devices and with DLC plug-in integration
+    Manufacturer = apps.get_model("dcim", "Manufacturer")
+    arista_manu = Manufacturer.objects.get_or_create(name="Arista", slug="arista")
+
     Platform = apps.get_model("dcim", "Platform")
-    Platform.objects.get_or_create(name="arista.eos.eos", slug="arista_eos", napalm_driver="eos")
+    Platform.objects.get_or_create(
+        name="arista.eos.eos", slug="arista_eos", napalm_driver="eos", manufacturer=arista_manu
+    )

--- a/nautobot_ssot_aristacv/utils/cloudvision.py
+++ b/nautobot_ssot_aristacv/utils/cloudvision.py
@@ -509,7 +509,9 @@ def get_interfaces_chassis(client: CloudvisionApi, dId):
                             "oper_status": "up"
                             if results.get("operStatus") and results["operStatus"]["Name"] == "intfOperUp"
                             else "down",
-                            "enabled": bool(results["enabledState"]["Name"] == "enabled"),
+                            "enabled": bool(results["enabledState"]["Name"] == "enabled")
+                            if results.get("enabledState")
+                            else False,
                             "mac_addr": results["burnedInAddr"],
                             "mtu": results["mtu"],
                         }

--- a/nautobot_ssot_aristacv/utils/nautobot.py
+++ b/nautobot_ssot_aristacv/utils/nautobot.py
@@ -105,5 +105,5 @@ def get_device_version(device):
         except KeyError:
             pass
     else:
-        version = device.custom_field_data["eos_version"]
+        version = device.custom_field_data["arista_eos"]
     return version

--- a/nautobot_ssot_aristacv/utils/nautobot.py
+++ b/nautobot_ssot_aristacv/utils/nautobot.py
@@ -27,16 +27,6 @@ def verify_site(site_name):
     return site_obj
 
 
-def verify_manufacturer():
-    """Verifies whether Arista manufactere exists in Nautobot. If not, creates Arista Manufacturer."""
-    try:
-        arista_mf = Manufacturer.objects.get(name="Arista")
-    except Manufacturer.DoesNotExist:
-        arista_mf = Manufacturer(name="Arista", slug="arista")
-        arista_mf.validated_save()
-    return arista_mf
-
-
 def verify_device_type_object(device_type):
     """Verifies whether device type object already exists in Nautobot. If not, creates specified device type.
 
@@ -46,8 +36,9 @@ def verify_device_type_object(device_type):
     try:
         device_type_obj = DeviceType.objects.get(model=device_type)
     except DeviceType.DoesNotExist:
-        manufacturer = verify_manufacturer()
-        device_type_obj = DeviceType(manufacturer=manufacturer, model=device_type, slug=device_type.lower())
+        device_type_obj = DeviceType(
+            manufacturer=Manufacturer.objects.get(name="Arista"), model=device_type, slug=device_type.lower()
+        )
         device_type_obj.validated_save()
     return device_type_obj
 

--- a/nautobot_ssot_aristacv/utils/nautobot.py
+++ b/nautobot_ssot_aristacv/utils/nautobot.py
@@ -5,7 +5,7 @@ from nautobot.dcim.models import DeviceRole, DeviceType, Manufacturer, Site
 from nautobot.extras.models import Status, Tag, Relationship
 
 try:
-    from nautobot_device_lifecycle_mgmt.models import SoftwareLCM
+    from nautobot_device_lifecycle_mgmt.models import SoftwareLCM  # noqa: F401 # pylint: disable=unused-import
 
     LIFECYCLE_MGMT = True
 except ImportError:
@@ -114,5 +114,5 @@ def get_device_version(device):
         except KeyError:
             pass
     else:
-        version = device._custom_field_data["eos_version"]
+        version = device.custom_field_data["eos_version"]
     return version

--- a/poetry.lock
+++ b/poetry.lock
@@ -341,6 +341,14 @@ ssh = ["bcrypt (>=3.1.5)"]
 test = ["pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
 
 [[package]]
+name = "cycler"
+version = "0.11.0"
+description = "Composable style cycles"
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[[package]]
 name = "defusedxml"
 version = "0.7.1"
 description = "XML bomb protection for Python stdlib modules"
@@ -797,6 +805,28 @@ pycodestyle = ">=2.7.0,<2.8.0"
 pyflakes = ">=2.3.0,<2.4.0"
 
 [[package]]
+name = "fonttools"
+version = "4.37.4"
+description = "Tools to manipulate font files"
+category = "main"
+optional = true
+python-versions = ">=3.7"
+
+[package.extras]
+all = ["fs (>=2.2.0,<3)", "lxml (>=4.0,<5)", "zopfli (>=0.1.4)", "lz4 (>=1.7.4.2)", "matplotlib", "sympy", "skia-pathops (>=0.5.0)", "uharfbuzz (>=0.23.0)", "brotlicffi (>=0.8.0)", "scipy", "brotli (>=1.0.1)", "munkres", "unicodedata2 (>=14.0.0)", "xattr"]
+graphite = ["lz4 (>=1.7.4.2)"]
+interpolatable = ["scipy", "munkres"]
+lxml = ["lxml (>=4.0,<5)"]
+pathops = ["skia-pathops (>=0.5.0)"]
+plot = ["matplotlib"]
+repacker = ["uharfbuzz (>=0.23.0)"]
+symfont = ["sympy"]
+type1 = ["xattr"]
+ufo = ["fs (>=2.2.0,<3)"]
+unicode = ["unicodedata2 (>=14.0.0)"]
+woff = ["zopfli (>=0.1.4)", "brotlicffi (>=0.8.0)", "brotli (>=1.0.1)"]
+
+[[package]]
 name = "funcy"
 version = "1.17"
 description = "A fancy and practical functional tools"
@@ -1046,6 +1076,17 @@ format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validat
 format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "uri-template", "webcolors (>=1.11)"]
 
 [[package]]
+name = "kiwisolver"
+version = "1.4.4"
+description = "A fast implementation of the Cassowary constraint solver"
+category = "main"
+optional = true
+python-versions = ">=3.7"
+
+[package.dependencies]
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
+
+[[package]]
 name = "kombu"
 version = "5.2.4"
 description = "Messaging library for Python."
@@ -1115,6 +1156,25 @@ description = "Safely add untrusted strings to HTML/XML markup."
 category = "main"
 optional = false
 python-versions = ">=3.7"
+
+[[package]]
+name = "matplotlib"
+version = "3.5.3"
+description = "Python plotting package"
+category = "main"
+optional = true
+python-versions = ">=3.7"
+
+[package.dependencies]
+cycler = ">=0.10"
+fonttools = ">=4.22.0"
+kiwisolver = ">=1.0.1"
+numpy = ">=1.17"
+packaging = ">=20.0"
+pillow = ">=6.2.0"
+pyparsing = ">=2.2.1"
+python-dateutil = ">=2.7"
+setuptools_scm = ">=4,<7"
 
 [[package]]
 name = "mccabe"
@@ -1225,12 +1285,24 @@ social-auth-app-django = ">=5.0.0,<5.1.0"
 svgwrite = ">=1.4.2,<1.5.0"
 
 [package.extras]
-all = ["django-auth-ldap (>=4.1.0,<4.2.0)", "django-storages (>=1.12.3,<1.13.0)", "mysqlclient (>=2.1.0,<2.2.0)", "napalm (>=3.4.1,<3.5.0)", "social-auth-core[openidconnect,saml] (>=4.3.0,<4.4.0)"]
+all = ["django-auth-ldap (>=4.1.0,<4.2.0)", "django-storages (>=1.12.3,<1.13.0)", "mysqlclient (>=2.1.0,<2.2.0)", "napalm (>=3.4.1,<3.5.0)", "social-auth-core[saml,openidconnect] (>=4.3.0,<4.4.0)"]
 ldap = ["django-auth-ldap (>=4.1.0,<4.2.0)"]
 remote_storage = ["django-storages (>=1.12.3,<1.13.0)"]
 mysql = ["mysqlclient (>=2.1.0,<2.2.0)"]
 napalm = ["napalm (>=3.4.1,<3.5.0)"]
-sso = ["social-auth-core[openidconnect,saml] (>=4.3.0,<4.4.0)"]
+sso = ["social-auth-core[saml,openidconnect] (>=4.3.0,<4.4.0)"]
+
+[[package]]
+name = "nautobot-device-lifecycle-mgmt"
+version = "1.0.2"
+description = "Manages device lifecycles for platforms and software."
+category = "main"
+optional = true
+python-versions = ">=3.6.2,<4.0.0"
+
+[package.dependencies]
+matplotlib = ">=3.3.4,<4.0.0"
+pycountry = ">=20.7.3,<21.0.0"
 
 [[package]]
 name = "nautobot-ssot"
@@ -1260,6 +1332,14 @@ description = "Common helper functions useful in network automation."
 category = "main"
 optional = false
 python-versions = ">=3.6,<4.0"
+
+[[package]]
+name = "numpy"
+version = "1.21.1"
+description = "NumPy is the fundamental package for array computing with Python."
+category = "main"
+optional = true
+python-versions = ">=3.7"
 
 [[package]]
 name = "oauthlib"
@@ -1395,6 +1475,14 @@ description = "Python style guide checker"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pycountry"
+version = "20.7.3"
+description = "ISO country, subdivision, language, currency and script definitions and their translations"
+category = "main"
+optional = true
+python-versions = "*"
 
 [[package]]
 name = "pycparser"
@@ -1702,6 +1790,22 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "setuptools-scm"
+version = "6.4.2"
+description = "the blessed package to manage your versions by scm tags"
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[package.dependencies]
+packaging = ">=20.0"
+tomli = ">=1.0.0"
+
+[package.extras]
+test = ["pytest (>=6.2)", "virtualenv (>20)"]
+toml = ["setuptools (>=42)"]
+
+[[package]]
 name = "singledispatch"
 version = "3.7.0"
 description = "Backport functools.singledispatch from Python 3.4 to Python 2.6-3.3."
@@ -1844,7 +1948,7 @@ python-versions = "*"
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -1982,7 +2086,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "337405844556baa9d2fd3b934461145a60481c3036f8e11e9bd3713fdcf595d3"
+content-hash = "6360725704ddfcd274d4c1f467c8ae1b9c64322aa3c1292a0cd8bec56e89b293"
 
 [metadata.files]
 amqp = [
@@ -2119,6 +2223,10 @@ coreschema = [
 ]
 coverage = []
 cryptography = []
+cycler = [
+    {file = "cycler-0.11.0-py3-none-any.whl", hash = "sha256:3a27e95f763a428a739d2add979fa7494c912a32c17c4c38c4d5f082cad165a3"},
+    {file = "cycler-0.11.0.tar.gz", hash = "sha256:9c87405839a19696e837b3b818fed3f5f69f16f1eec1a1ad77e043dcea9c772f"},
+]
 defusedxml = [
     {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
     {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
@@ -2227,6 +2335,7 @@ flake8 = [
     {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
     {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
 ]
+fonttools = []
 funcy = [
     {file = "funcy-1.17-py2.py3-none-any.whl", hash = "sha256:ba7af5e58bfc69321aaf860a1547f18d35e145706b95d1b3c966abc4f0b60309"},
     {file = "funcy-1.17.tar.gz", hash = "sha256:40b9b9a88141ae6a174df1a95861f2b82f2fdc17669080788b73a3ed9370e968"},
@@ -2284,6 +2393,7 @@ jinja2 = [
     {file = "Jinja2-3.0.3.tar.gz", hash = "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"},
 ]
 jsonschema = []
+kiwisolver = []
 kombu = [
     {file = "kombu-5.2.4-py3-none-any.whl", hash = "sha256:8b213b24293d3417bcf0d2f5537b7f756079e3ea232a8386dcc89a59fd2361a4"},
     {file = "kombu-5.2.4.tar.gz", hash = "sha256:37cee3ee725f94ea8bb173eaab7c1760203ea53bbebae226328600f9d2799610"},
@@ -2374,6 +2484,7 @@ markupsafe = [
     {file = "MarkupSafe-2.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247"},
     {file = "MarkupSafe-2.1.1.tar.gz", hash = "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b"},
 ]
+matplotlib = []
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
@@ -2442,6 +2553,10 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 nautobot = []
+nautobot-device-lifecycle-mgmt = [
+    {file = "nautobot-device-lifecycle-mgmt-1.0.2.tar.gz", hash = "sha256:bb5f412044d0bb07c4dc427abce8bf55004f41a4bb5621e76ebc2baa023ccdc2"},
+    {file = "nautobot_device_lifecycle_mgmt-1.0.2-py3-none-any.whl", hash = "sha256:ec80e365244c7b70eb89fdaab7e4929c32b3bb0a6e02a02a657ee3fec60502ee"},
+]
 nautobot-ssot = [
     {file = "nautobot-ssot-1.1.2.tar.gz", hash = "sha256:869b1178674fca883789a69a08956434141a9a93d83c19711f17b05305b06983"},
     {file = "nautobot_ssot-1.1.2-py3-none-any.whl", hash = "sha256:799f43320694bfdcb2f771f23903d65b68dae176c8c3cdc82bd49c74d0fd7697"},
@@ -2451,6 +2566,36 @@ netaddr = [
     {file = "netaddr-0.8.0.tar.gz", hash = "sha256:d6cc57c7a07b1d9d2e917aa8b36ae8ce61c35ba3fcd1b83ca31c5a0ee2b5a243"},
 ]
 netutils = []
+numpy = [
+    {file = "numpy-1.21.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:38e8648f9449a549a7dfe8d8755a5979b45b3538520d1e735637ef28e8c2dc50"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:fd7d7409fa643a91d0a05c7554dd68aa9c9bb16e186f6ccfe40d6e003156e33a"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a75b4498b1e93d8b700282dc8e655b8bd559c0904b3910b144646dbbbc03e062"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1412aa0aec3e00bc23fbb8664d76552b4efde98fb71f60737c83efbac24112f1"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e46ceaff65609b5399163de5893d8f2a82d3c77d5e56d976c8b5fb01faa6b671"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:c6a2324085dd52f96498419ba95b5777e40b6bcbc20088fddb9e8cbb58885e8e"},
+    {file = "numpy-1.21.1-cp37-cp37m-win32.whl", hash = "sha256:73101b2a1fef16602696d133db402a7e7586654682244344b8329cdcbbb82172"},
+    {file = "numpy-1.21.1-cp37-cp37m-win_amd64.whl", hash = "sha256:7a708a79c9a9d26904d1cca8d383bf869edf6f8e7650d85dbc77b041e8c5a0f8"},
+    {file = "numpy-1.21.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:95b995d0c413f5d0428b3f880e8fe1660ff9396dcd1f9eedbc311f37b5652e16"},
+    {file = "numpy-1.21.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:635e6bd31c9fb3d475c8f44a089569070d10a9ef18ed13738b03049280281267"},
+    {file = "numpy-1.21.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4a3d5fb89bfe21be2ef47c0614b9c9c707b7362386c9a3ff1feae63e0267ccb6"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8a326af80e86d0e9ce92bcc1e65c8ff88297de4fa14ee936cb2293d414c9ec63"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:791492091744b0fe390a6ce85cc1bf5149968ac7d5f0477288f78c89b385d9af"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0318c465786c1f63ac05d7c4dbcecd4d2d7e13f0959b01b534ea1e92202235c5"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9a513bd9c1551894ee3d31369f9b07460ef223694098cf27d399513415855b68"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:91c6f5fc58df1e0a3cc0c3a717bb3308ff850abdaa6d2d802573ee2b11f674a8"},
+    {file = "numpy-1.21.1-cp38-cp38-win32.whl", hash = "sha256:978010b68e17150db8765355d1ccdd450f9fc916824e8c4e35ee620590e234cd"},
+    {file = "numpy-1.21.1-cp38-cp38-win_amd64.whl", hash = "sha256:9749a40a5b22333467f02fe11edc98f022133ee1bfa8ab99bda5e5437b831214"},
+    {file = "numpy-1.21.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:d7a4aeac3b94af92a9373d6e77b37691b86411f9745190d2c351f410ab3a791f"},
+    {file = "numpy-1.21.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d9e7912a56108aba9b31df688a4c4f5cb0d9d3787386b87d504762b6754fbb1b"},
+    {file = "numpy-1.21.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:25b40b98ebdd272bc3020935427a4530b7d60dfbe1ab9381a39147834e985eac"},
+    {file = "numpy-1.21.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8a92c5aea763d14ba9d6475803fc7904bda7decc2a0a68153f587ad82941fec1"},
+    {file = "numpy-1.21.1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:05a0f648eb28bae4bcb204e6fd14603de2908de982e761a2fc78efe0f19e96e1"},
+    {file = "numpy-1.21.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f01f28075a92eede918b965e86e8f0ba7b7797a95aa8d35e1cc8821f5fc3ad6a"},
+    {file = "numpy-1.21.1-cp39-cp39-win32.whl", hash = "sha256:88c0b89ad1cc24a5efbb99ff9ab5db0f9a86e9cc50240177a571fbe9c2860ac2"},
+    {file = "numpy-1.21.1-cp39-cp39-win_amd64.whl", hash = "sha256:01721eefe70544d548425a07c80be8377096a54118070b8a62476866d5208e33"},
+    {file = "numpy-1.21.1-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2d4d1de6e6fb3d28781c73fbde702ac97f03d79e4ffd6598b880b2d95d62ead4"},
+    {file = "numpy-1.21.1.zip", hash = "sha256:dff4af63638afcc57a3dfb9e4b26d434a7a602d225b42d746ea7fe2edf1342fd"},
+]
 oauthlib = []
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
@@ -2537,6 +2682,9 @@ psycopg2-binary = [
 pycodestyle = [
     {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
     {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
+]
+pycountry = [
+    {file = "pycountry-20.7.3.tar.gz", hash = "sha256:81084a53d3454344c0292deebc20fcd0a1488c136d4900312cbd465cf552cb42"},
 ]
 pycparser = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
@@ -2749,6 +2897,10 @@ rq = []
 rx = [
     {file = "Rx-1.6.1-py2.py3-none-any.whl", hash = "sha256:7357592bc7e881a95e0c2013b73326f704953301ab551fbc8133a6fadab84105"},
     {file = "Rx-1.6.1.tar.gz", hash = "sha256:13a1d8d9e252625c173dc795471e614eadfe1cf40ffc684e08b8fff0d9748c23"},
+]
+setuptools-scm = [
+    {file = "setuptools_scm-6.4.2-py3-none-any.whl", hash = "sha256:acea13255093849de7ccb11af9e1fb8bde7067783450cee9ef7a93139bddf6d4"},
+    {file = "setuptools_scm-6.4.2.tar.gz", hash = "sha256:6833ac65c6ed9711a4d5d2266f8024cfa07c533a0e55f4c12f6eff280a5a9e30"},
 ]
 singledispatch = [
     {file = "singledispatch-3.7.0-py2.py3-none-any.whl", hash = "sha256:bc77afa97c8a22596d6d4fc20f1b7bdd2b86edc2a65a4262bdd7cc3cc19aa989"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -99,11 +99,11 @@ python-versions = "*"
 
 [[package]]
 name = "black"
-version = "22.8.0"
+version = "22.10.0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
-python-versions = ">=3.6.2"
+python-versions = ">=3.7"
 
 [package.dependencies]
 click = ">=8.0.0"
@@ -262,7 +262,7 @@ six = "*"
 
 [[package]]
 name = "cloudvision"
-version = "1.5.0.post3"
+version = "1.6.0"
 description = "A Python library for Arista's CloudVision APIs."
 category = "main"
 optional = false
@@ -323,7 +323,7 @@ toml = ["tomli"]
 
 [[package]]
 name = "cryptography"
-version = "38.0.1"
+version = "38.0.2"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = false
@@ -861,7 +861,7 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.27"
+version = "3.1.29"
 description = "GitPython is a python library used to interact with Git repositories"
 category = "main"
 optional = false
@@ -991,7 +991,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "flake8 
 
 [[package]]
 name = "importlib-resources"
-version = "5.9.0"
+version = "5.10.0"
 description = "Read resources from Python packages"
 category = "main"
 optional = false
@@ -1001,8 +1001,8 @@ python-versions = ">=3.7"
 zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+docs = ["sphinx (>=3.5)", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "furo", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "flake8 (<5)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
 name = "inflection"
@@ -1194,7 +1194,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "mkdocs"
-version = "1.4.0"
+version = "1.4.1"
 description = "Project documentation with Markdown."
 category = "dev"
 optional = false
@@ -1202,18 +1202,20 @@ python-versions = ">=3.7"
 
 [package.dependencies]
 click = ">=7.0"
+colorama = {version = ">=0.4", markers = "platform_system == \"Windows\""}
 ghp-import = ">=1.0"
 importlib-metadata = {version = ">=4.3", markers = "python_version < \"3.10\""}
-Jinja2 = ">=2.11.1"
-Markdown = ">=3.2.1,<3.4"
+jinja2 = ">=2.11.1"
+markdown = ">=3.2.1,<3.4"
 mergedeep = ">=1.3.4"
 packaging = ">=20.5"
-PyYAML = ">=5.1"
+pyyaml = ">=5.1"
 pyyaml-env-tag = ">=0.1"
 typing-extensions = {version = ">=3.10", markers = "python_version < \"3.8\""}
 watchdog = ">=2.0"
 
 [package.extras]
+min-versions = ["watchdog (==2.0)", "typing-extensions (==3.10)", "pyyaml (==5.1)", "pyyaml-env-tag (==0.1)", "packaging (==20.5)", "mergedeep (==1.3.4)", "markupsafe (==2.0.1)", "markdown (==3.2.1)", "jinja2 (==2.11.1)", "importlib-metadata (==4.3)", "ghp-import (==1.0)", "colorama (==0.4)", "click (==7.0)", "babel (==2.9.0)"]
 i18n = ["babel (>=2.9.0)"]
 
 [[package]]
@@ -1306,16 +1308,17 @@ pycountry = ">=20.7.3,<21.0.0"
 
 [[package]]
 name = "nautobot-ssot"
-version = "1.1.2"
+version = "1.2.0"
 description = "Nautobot Single Source of Truth"
 category = "main"
 optional = false
-python-versions = ">=3.6,<4.0"
+python-versions = ">=3.7,<4.0"
 
 [package.dependencies]
-diffsync = ">=1.3.0,<2.0.0"
+diffsync = ">=1.6.0,<2.0.0"
 Markdown = "!=3.3.5"
-nautobot = ">=1.0.3,<2.0.0"
+nautobot = "*"
+packaging = ">=21.3,<22.0"
 
 [[package]]
 name = "netaddr"
@@ -1418,7 +1421,7 @@ test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytes
 
 [[package]]
 name = "prometheus-client"
-version = "0.14.1"
+version = "0.15.0"
 description = "Python client for the Prometheus monitoring system."
 category = "main"
 optional = false
@@ -1462,7 +1465,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "psycopg2-binary"
-version = "2.9.3"
+version = "2.9.4"
 description = "psycopg2 - Python-PostgreSQL Database Adapter"
 category = "main"
 optional = false
@@ -1889,7 +1892,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "stevedore"
-version = "3.5.0"
+version = "3.5.1"
 description = "Manage dynamic plugins for Python applications"
 category = "dev"
 optional = false
@@ -1978,7 +1981,7 @@ python-versions = "*"
 
 [[package]]
 name = "types-requests"
-version = "2.28.11.1"
+version = "2.28.11.2"
 description = "Typing stubs for requests"
 category = "main"
 optional = false
@@ -1989,7 +1992,7 @@ types-urllib3 = "<1.27"
 
 [[package]]
 name = "types-urllib3"
-version = "1.26.25"
+version = "1.26.25.1"
 description = "Typing stubs for urllib3"
 category = "main"
 optional = false
@@ -1997,7 +2000,7 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "4.3.0"
+version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
@@ -2073,20 +2076,24 @@ pyyaml = "*"
 
 [[package]]
 name = "zipp"
-version = "3.8.1"
+version = "3.9.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+docs = ["sphinx (>=3.5)", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "furo", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "flake8 (<5)", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "jaraco.functools", "more-itertools", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+
+[extras]
+nautobot = ["nautobot"]
+nautobot-device-lifecycle-mgmt = ["nautobot-device-lifecycle-mgmt"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "6360725704ddfcd274d4c1f467c8ae1b9c64322aa3c1292a0cd8bec56e89b293"
+content-hash = "9ef6a934806bbe8a9b39f50a133ce7e07a5d8911789a380c6fa00321e11ee311"
 
 [metadata.files]
 amqp = [
@@ -2348,10 +2355,7 @@ gitdb = [
     {file = "gitdb-4.0.9-py3-none-any.whl", hash = "sha256:8033ad4e853066ba6ca92050b9df2f89301b8fc8bf7e9324d412a63f8bf1a8fd"},
     {file = "gitdb-4.0.9.tar.gz", hash = "sha256:bac2fd45c0a1c9cf619e63a90d62bdc63892ef92387424b855792a6cabe789aa"},
 ]
-gitpython = [
-    {file = "GitPython-3.1.27-py3-none-any.whl", hash = "sha256:5b68b000463593e05ff2b261acff0ff0972df8ab1b70d3cdbd41b546c8b8fc3d"},
-    {file = "GitPython-3.1.27.tar.gz", hash = "sha256:1c885ce809e8ba2d88a29befeb385fcea06338d3640712b59ca623c220bb5704"},
-]
+gitpython = []
 graphene = [
     {file = "graphene-2.1.9-py2.py3-none-any.whl", hash = "sha256:3d446eb1237c551052bc31155cf1a3a607053e4f58c9172b83a1b597beaa0868"},
     {file = "graphene-2.1.9.tar.gz", hash = "sha256:b9f2850e064eebfee9a3ef4a1f8aa0742848d97652173ab44c82cc8a62b9ed93"},
@@ -2557,10 +2561,7 @@ nautobot-device-lifecycle-mgmt = [
     {file = "nautobot-device-lifecycle-mgmt-1.0.2.tar.gz", hash = "sha256:bb5f412044d0bb07c4dc427abce8bf55004f41a4bb5621e76ebc2baa023ccdc2"},
     {file = "nautobot_device_lifecycle_mgmt-1.0.2-py3-none-any.whl", hash = "sha256:ec80e365244c7b70eb89fdaab7e4929c32b3bb0a6e02a02a657ee3fec60502ee"},
 ]
-nautobot-ssot = [
-    {file = "nautobot-ssot-1.1.2.tar.gz", hash = "sha256:869b1178674fca883789a69a08956434141a9a93d83c19711f17b05305b06983"},
-    {file = "nautobot_ssot-1.1.2-py3-none-any.whl", hash = "sha256:799f43320694bfdcb2f771f23903d65b68dae176c8c3cdc82bd49c74d0fd7697"},
-]
+nautobot-ssot = []
 netaddr = [
     {file = "netaddr-0.8.0-py2.py3-none-any.whl", hash = "sha256:9666d0232c32d2656e5e5f8d735f58fd6c7457ce52fc21c98d45f2af78f990ac"},
     {file = "netaddr-0.8.0.tar.gz", hash = "sha256:d6cc57c7a07b1d9d2e917aa8b36ae8ce61c35ba3fcd1b83ca31c5a0ee2b5a243"},
@@ -2612,73 +2613,13 @@ platformdirs = [
     {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
     {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
 ]
-prometheus-client = [
-    {file = "prometheus_client-0.14.1-py3-none-any.whl", hash = "sha256:522fded625282822a89e2773452f42df14b5a8e84a86433e3f8a189c1d54dc01"},
-    {file = "prometheus_client-0.14.1.tar.gz", hash = "sha256:5459c427624961076277fdc6dc50540e2bacb98eebde99886e59ec55ed92093a"},
-]
+prometheus-client = []
 promise = [
     {file = "promise-2.3.tar.gz", hash = "sha256:dfd18337c523ba4b6a58801c164c1904a9d4d1b1747c7d5dbf45b693a49d93d0"},
 ]
 prompt-toolkit = []
 protobuf = []
-psycopg2-binary = [
-    {file = "psycopg2-binary-2.9.3.tar.gz", hash = "sha256:761df5313dc15da1502b21453642d7599d26be88bff659382f8f9747c7ebea4e"},
-    {file = "psycopg2_binary-2.9.3-cp310-cp310-macosx_10_14_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:539b28661b71da7c0e428692438efbcd048ca21ea81af618d845e06ebfd29478"},
-    {file = "psycopg2_binary-2.9.3-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6e82d38390a03da28c7985b394ec3f56873174e2c88130e6966cb1c946508e65"},
-    {file = "psycopg2_binary-2.9.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:57804fc02ca3ce0dbfbef35c4b3a4a774da66d66ea20f4bda601294ad2ea6092"},
-    {file = "psycopg2_binary-2.9.3-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:083a55275f09a62b8ca4902dd11f4b33075b743cf0d360419e2051a8a5d5ff76"},
-    {file = "psycopg2_binary-2.9.3-cp310-cp310-manylinux_2_24_ppc64le.whl", hash = "sha256:0a29729145aaaf1ad8bafe663131890e2111f13416b60e460dae0a96af5905c9"},
-    {file = "psycopg2_binary-2.9.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:3a79d622f5206d695d7824cbf609a4f5b88ea6d6dab5f7c147fc6d333a8787e4"},
-    {file = "psycopg2_binary-2.9.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:090f3348c0ab2cceb6dfbe6bf721ef61262ddf518cd6cc6ecc7d334996d64efa"},
-    {file = "psycopg2_binary-2.9.3-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:a9e1f75f96ea388fbcef36c70640c4efbe4650658f3d6a2967b4cc70e907352e"},
-    {file = "psycopg2_binary-2.9.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c3ae8e75eb7160851e59adc77b3a19a976e50622e44fd4fd47b8b18208189d42"},
-    {file = "psycopg2_binary-2.9.3-cp310-cp310-win32.whl", hash = "sha256:7b1e9b80afca7b7a386ef087db614faebbf8839b7f4db5eb107d0f1a53225029"},
-    {file = "psycopg2_binary-2.9.3-cp310-cp310-win_amd64.whl", hash = "sha256:8b344adbb9a862de0c635f4f0425b7958bf5a4b927c8594e6e8d261775796d53"},
-    {file = "psycopg2_binary-2.9.3-cp36-cp36m-macosx_10_14_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:e847774f8ffd5b398a75bc1c18fbb56564cda3d629fe68fd81971fece2d3c67e"},
-    {file = "psycopg2_binary-2.9.3-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:68641a34023d306be959101b345732360fc2ea4938982309b786f7be1b43a4a1"},
-    {file = "psycopg2_binary-2.9.3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3303f8807f342641851578ee7ed1f3efc9802d00a6f83c101d21c608cb864460"},
-    {file = "psycopg2_binary-2.9.3-cp36-cp36m-manylinux_2_24_aarch64.whl", hash = "sha256:e3699852e22aa68c10de06524a3721ade969abf382da95884e6a10ff798f9281"},
-    {file = "psycopg2_binary-2.9.3-cp36-cp36m-manylinux_2_24_ppc64le.whl", hash = "sha256:526ea0378246d9b080148f2d6681229f4b5964543c170dd10bf4faaab6e0d27f"},
-    {file = "psycopg2_binary-2.9.3-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:b1c8068513f5b158cf7e29c43a77eb34b407db29aca749d3eb9293ee0d3103ca"},
-    {file = "psycopg2_binary-2.9.3-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:15803fa813ea05bef089fa78835118b5434204f3a17cb9f1e5dbfd0b9deea5af"},
-    {file = "psycopg2_binary-2.9.3-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:152f09f57417b831418304c7f30d727dc83a12761627bb826951692cc6491e57"},
-    {file = "psycopg2_binary-2.9.3-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:404224e5fef3b193f892abdbf8961ce20e0b6642886cfe1fe1923f41aaa75c9d"},
-    {file = "psycopg2_binary-2.9.3-cp36-cp36m-win32.whl", hash = "sha256:1f6b813106a3abdf7b03640d36e24669234120c72e91d5cbaeb87c5f7c36c65b"},
-    {file = "psycopg2_binary-2.9.3-cp36-cp36m-win_amd64.whl", hash = "sha256:2d872e3c9d5d075a2e104540965a1cf898b52274a5923936e5bfddb58c59c7c2"},
-    {file = "psycopg2_binary-2.9.3-cp37-cp37m-macosx_10_14_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:10bb90fb4d523a2aa67773d4ff2b833ec00857f5912bafcfd5f5414e45280fb1"},
-    {file = "psycopg2_binary-2.9.3-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:874a52ecab70af13e899f7847b3e074eeb16ebac5615665db33bce8a1009cf33"},
-    {file = "psycopg2_binary-2.9.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a29b3ca4ec9defec6d42bf5feb36bb5817ba3c0230dd83b4edf4bf02684cd0ae"},
-    {file = "psycopg2_binary-2.9.3-cp37-cp37m-manylinux_2_24_aarch64.whl", hash = "sha256:12b11322ea00ad8db8c46f18b7dfc47ae215e4df55b46c67a94b4effbaec7094"},
-    {file = "psycopg2_binary-2.9.3-cp37-cp37m-manylinux_2_24_ppc64le.whl", hash = "sha256:53293533fcbb94c202b7c800a12c873cfe24599656b341f56e71dd2b557be063"},
-    {file = "psycopg2_binary-2.9.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:c381bda330ddf2fccbafab789d83ebc6c53db126e4383e73794c74eedce855ef"},
-    {file = "psycopg2_binary-2.9.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:9d29409b625a143649d03d0fd7b57e4b92e0ecad9726ba682244b73be91d2fdb"},
-    {file = "psycopg2_binary-2.9.3-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:183a517a3a63503f70f808b58bfbf962f23d73b6dccddae5aa56152ef2bcb232"},
-    {file = "psycopg2_binary-2.9.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:15c4e4cfa45f5a60599d9cec5f46cd7b1b29d86a6390ec23e8eebaae84e64554"},
-    {file = "psycopg2_binary-2.9.3-cp37-cp37m-win32.whl", hash = "sha256:adf20d9a67e0b6393eac162eb81fb10bc9130a80540f4df7e7355c2dd4af9fba"},
-    {file = "psycopg2_binary-2.9.3-cp37-cp37m-win_amd64.whl", hash = "sha256:2f9ffd643bc7349eeb664eba8864d9e01f057880f510e4681ba40a6532f93c71"},
-    {file = "psycopg2_binary-2.9.3-cp38-cp38-macosx_10_14_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:def68d7c21984b0f8218e8a15d514f714d96904265164f75f8d3a70f9c295667"},
-    {file = "psycopg2_binary-2.9.3-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dffc08ca91c9ac09008870c9eb77b00a46b3378719584059c034b8945e26b272"},
-    {file = "psycopg2_binary-2.9.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:280b0bb5cbfe8039205c7981cceb006156a675362a00fe29b16fbc264e242834"},
-    {file = "psycopg2_binary-2.9.3-cp38-cp38-manylinux_2_24_aarch64.whl", hash = "sha256:af9813db73395fb1fc211bac696faea4ca9ef53f32dc0cfa27e4e7cf766dcf24"},
-    {file = "psycopg2_binary-2.9.3-cp38-cp38-manylinux_2_24_ppc64le.whl", hash = "sha256:63638d875be8c2784cfc952c9ac34e2b50e43f9f0a0660b65e2a87d656b3116c"},
-    {file = "psycopg2_binary-2.9.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:ffb7a888a047696e7f8240d649b43fb3644f14f0ee229077e7f6b9f9081635bd"},
-    {file = "psycopg2_binary-2.9.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:0c9d5450c566c80c396b7402895c4369a410cab5a82707b11aee1e624da7d004"},
-    {file = "psycopg2_binary-2.9.3-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:d1c1b569ecafe3a69380a94e6ae09a4789bbb23666f3d3a08d06bbd2451f5ef1"},
-    {file = "psycopg2_binary-2.9.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8fc53f9af09426a61db9ba357865c77f26076d48669f2e1bb24d85a22fb52307"},
-    {file = "psycopg2_binary-2.9.3-cp38-cp38-win32.whl", hash = "sha256:6472a178e291b59e7f16ab49ec8b4f3bdada0a879c68d3817ff0963e722a82ce"},
-    {file = "psycopg2_binary-2.9.3-cp38-cp38-win_amd64.whl", hash = "sha256:35168209c9d51b145e459e05c31a9eaeffa9a6b0fd61689b48e07464ffd1a83e"},
-    {file = "psycopg2_binary-2.9.3-cp39-cp39-macosx_10_14_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:47133f3f872faf28c1e87d4357220e809dfd3fa7c64295a4a148bcd1e6e34ec9"},
-    {file = "psycopg2_binary-2.9.3-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:91920527dea30175cc02a1099f331aa8c1ba39bf8b7762b7b56cbf54bc5cce42"},
-    {file = "psycopg2_binary-2.9.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:887dd9aac71765ac0d0bac1d0d4b4f2c99d5f5c1382d8b770404f0f3d0ce8a39"},
-    {file = "psycopg2_binary-2.9.3-cp39-cp39-manylinux_2_24_aarch64.whl", hash = "sha256:1f14c8b0942714eb3c74e1e71700cbbcb415acbc311c730370e70c578a44a25c"},
-    {file = "psycopg2_binary-2.9.3-cp39-cp39-manylinux_2_24_ppc64le.whl", hash = "sha256:7af0dd86ddb2f8af5da57a976d27cd2cd15510518d582b478fbb2292428710b4"},
-    {file = "psycopg2_binary-2.9.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:93cd1967a18aa0edd4b95b1dfd554cf15af657cb606280996d393dadc88c3c35"},
-    {file = "psycopg2_binary-2.9.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:bda845b664bb6c91446ca9609fc69f7db6c334ec5e4adc87571c34e4f47b7ddb"},
-    {file = "psycopg2_binary-2.9.3-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:01310cf4cf26db9aea5158c217caa92d291f0500051a6469ac52166e1a16f5b7"},
-    {file = "psycopg2_binary-2.9.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:99485cab9ba0fa9b84f1f9e1fef106f44a46ef6afdeec8885e0b88d0772b49e8"},
-    {file = "psycopg2_binary-2.9.3-cp39-cp39-win32.whl", hash = "sha256:46f0e0a6b5fa5851bbd9ab1bc805eef362d3a230fbdfbc209f4a236d0a7a990d"},
-    {file = "psycopg2_binary-2.9.3-cp39-cp39-win_amd64.whl", hash = "sha256:accfe7e982411da3178ec690baaceaad3c278652998b2c45828aaac66cd8285f"},
-]
+psycopg2-binary = []
 pycodestyle = [
     {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
     {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
@@ -2927,10 +2868,7 @@ social-auth-core = [
     {file = "social_auth_core-4.3.0-py3-none-any.whl", hash = "sha256:1e3440d104f743b02dfe258c9d4dba5b4065abf24b2f7eb362b47054d21797df"},
 ]
 sqlparse = []
-stevedore = [
-    {file = "stevedore-3.5.0-py3-none-any.whl", hash = "sha256:a547de73308fd7e90075bb4d301405bebf705292fa90a90fc3bcf9133f58616c"},
-    {file = "stevedore-3.5.0.tar.gz", hash = "sha256:f40253887d8712eaa2bb0ea3830374416736dc8ec0e22f5a65092c1174c44335"},
-]
+stevedore = []
 structlog = [
     {file = "structlog-21.5.0-py3-none-any.whl", hash = "sha256:fd7922e195262b337da85c2a91c84be94ccab1f8fd1957bd6986f6904e3761c8"},
     {file = "structlog-21.5.0.tar.gz", hash = "sha256:68c4c29c003714fe86834f347cb107452847ba52414390a7ee583472bde00fc9"},
@@ -2975,10 +2913,7 @@ types-protobuf = []
 types-pyyaml = []
 types-requests = []
 types-urllib3 = []
-typing-extensions = [
-    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
-    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
-]
+typing-extensions = []
 uritemplate = [
     {file = "uritemplate-4.1.1-py2.py3-none-any.whl", hash = "sha256:830c08b8d99bdd312ea4ead05994a38e8936266f84b9a7878232db50b044e02e"},
     {file = "uritemplate-4.1.1.tar.gz", hash = "sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ python = "^3.7"
 nautobot = "^1.2.0"
 nautobot-ssot = "^1.0.1"
 cloudvision = "^1.5.0"
+nautobot-device-lifecycle-mgmt = {version = "^1.0.2", optional = true}
 
 [tool.poetry.dev-dependencies]
 invoke = "*"
@@ -38,6 +39,10 @@ coverage = "*"
 mkdocs = "*"
 markdown-include = "*"
 parameterized = "^0.8.1"
+
+[tool.poetry.extras]
+nautobot = ["nautobot"]
+nautobot-device-lifecycle-mgmt = ["nautobot-device-lifecycle-mgmt"]
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
This PR adds support for integrating with the Device Lifecycle plug-in requested in #87. It determines if the plug-in is installed by trying to import the SoftwareLCM model. If it can, it's determined to be installed and will thus create a Software Version and create a RelationshipAssocation between the Device and that Version. If the plug-in isn't found, it'll resort to the CustomField created from the tag. There's also a small fix for the platform bug described in #100.