### PR TITLE
Ensure site/role mapping to be plural

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ PLUGINS_CONFIG = {
     "apply_import_tag": is_truthy(os.getenv("NAUTOBOT_ARISTACV_IMPORT_TAG", False)),
     "import_active": is_truthy(os.getenv("NAUTOBOT_ARISTACV_IMPORT_ACTIVE", False)),
     "hostname_patterns": [""],
-    "site_mapping": {},
-    "role_mapping": {},
+    "site_mappings": {},
+    "role_mappings": {},
   }
 }
 ```

--- a/nautobot_ssot_aristacv/__init__.py
+++ b/nautobot_ssot_aristacv/__init__.py
@@ -33,8 +33,8 @@ class NautobotSSOTAristaCVConfig(PluginConfig):
         "verify": os.getenv("NAUTOBOT_ARISTACVP_VERIFY"),
         "cvp_token": os.getenv("NAUTOBOT_ARISTACV_TOKEN"),
         "hostname_patterns": [],
-        "site_mapping": {},
-        "role_mapping": {},
+        "site_mappings": {},
+        "role_mappings": {},
     }
     caching_config = {}
 

--- a/nautobot_ssot_aristacv/tests/test_utils_nautobot.py
+++ b/nautobot_ssot_aristacv/tests/test_utils_nautobot.py
@@ -33,28 +33,28 @@ class TestNautobotUtils(TestCase):
         expected = ("ams01", "leaf")
         self.assertEqual(results, expected)
 
-    @override_settings(PLUGINS_CONFIG={"nautobot_ssot_aristacv": {"site_mapping": {"ams01": "Amsterdam"}}})
+    @override_settings(PLUGINS_CONFIG={"nautobot_ssot_aristacv": {"site_mappings": {"ams01": "Amsterdam"}}})
     def test_get_site_from_map_success(self):
         """Test the get_site_from_map method with response."""
         results = nautobot.get_site_from_map("ams01")
         expected = "Amsterdam"
         self.assertEqual(results, expected)
 
-    @override_settings(PLUGINS_CONFIG={"nautobot_ssot_aristacv": {"site_mapping": {}}})
+    @override_settings(PLUGINS_CONFIG={"nautobot_ssot_aristacv": {"site_mappings": {}}})
     def test_get_site_from_map_fail(self):
         """Test the get_site_from_map method with failed response."""
         results = nautobot.get_site_from_map("dc01")
         expected = None
         self.assertEqual(results, expected)
 
-    @override_settings(PLUGINS_CONFIG={"nautobot_ssot_aristacv": {"role_mapping": {"edge": "Edge Router"}}})
+    @override_settings(PLUGINS_CONFIG={"nautobot_ssot_aristacv": {"role_mappings": {"edge": "Edge Router"}}})
     def test_get_role_from_map_success(self):
         """Test the get_role_from_map method with response."""
         results = nautobot.get_role_from_map("edge")
         expected = "Edge Router"
         self.assertEqual(results, expected)
 
-    @override_settings(PLUGINS_CONFIG={"nautobot_ssot_aristacv": {"role_mapping": {}}})
+    @override_settings(PLUGINS_CONFIG={"nautobot_ssot_aristacv": {"role_mappings": {}}})
     def test_get_role_from_map_fail(self):
         """Test the get_role_from_map method with failed response."""
         results = nautobot.get_role_from_map("rtr")

--- a/nautobot_ssot_aristacv/utils/nautobot.py
+++ b/nautobot_ssot_aristacv/utils/nautobot.py
@@ -140,7 +140,7 @@ def get_site_from_map(site_code: str):
     Returns:
         str|None: Name of Site if site code found else None.
     """
-    site_map = settings.PLUGINS_CONFIG["nautobot_ssot_aristacv"].get("site_mapping")
+    site_map = settings.PLUGINS_CONFIG["nautobot_ssot_aristacv"].get("site_mappings")
     site_name = None
     if site_code in site_map:
         site_name = site_map[site_code]

--- a/nautobot_ssot_aristacv/utils/nautobot.py
+++ b/nautobot_ssot_aristacv/utils/nautobot.py
@@ -156,7 +156,7 @@ def get_role_from_map(role_code: str):
     Returns:
         str|None: Name of Device Role if role code found else None.
     """
-    role_map = settings.PLUGINS_CONFIG["nautobot_ssot_aristacv"].get("role_mapping")
+    role_map = settings.PLUGINS_CONFIG["nautobot_ssot_aristacv"].get("role_mappings")
     role_name = None
     if role_code in role_map:
         role_name = role_map[role_code]


### PR DESCRIPTION
It looks like I missed a few places where I have the wrong form of the plugin setting for site and role mappings. Should be plural. I've updated it everywhere that it was still singular. Should be consistent everywhere now.