### PR TITLE
Fix DLC Integration and AP Handling

### DIFF
--- a/nautobot_ssot_aristacv/diffsync/adapters/cloudvision.py
+++ b/nautobot_ssot_aristacv/diffsync/adapters/cloudvision.py
@@ -67,6 +67,11 @@ class CloudvisionAdapter(DiffSync):
             port_info = cloudvision.get_interfaces_chassis(client=self.conn, dId=device.serial)
         elif chassis_type == "fixedSystem":
             port_info = cloudvision.get_interfaces_fixed(client=self.conn, dId=device.serial)
+        elif chassis_type == "Unknown":
+            self.job.log_warning(
+                message=f"Unable to determine chassis type for {device.name} so will be unable to retrieve interfaces."
+            )
+            return None
         if self.job.kwargs.get("debug"):
             self.job.log_debug(message=f"Device being loaded: {device.name}. Port: {port_info}.")
         for port in port_info:

--- a/nautobot_ssot_aristacv/tests/test_utils_cloudvision.py
+++ b/nautobot_ssot_aristacv/tests/test_utils_cloudvision.py
@@ -159,6 +159,15 @@ class TestCloudvisionUtils(TestCase):
             results = cloudvision.get_device_type(client=self.client, dId="JPE12345678")
         self.assertEqual(results, "fixedSystem")
 
+    def test_get_device_type_unknown(self):
+        """Test the get_device_type method for unknown type."""
+        mock_query = MagicMock()
+        mock_query.return_value = {}
+
+        with patch("nautobot_ssot_aristacv.utils.cloudvision.unfreeze_frozen_dict", mock_query):
+            results = cloudvision.get_device_type(client=self.client, dId="JPE12345678")
+        self.assertEqual(results, "Unknown")
+
     def test_get_interfaces_fixed(self):
         """Test get_interfaces_fixed method."""
         mock_query = MagicMock()

--- a/nautobot_ssot_aristacv/utils/cloudvision.py
+++ b/nautobot_ssot_aristacv/utils/cloudvision.py
@@ -443,10 +443,12 @@ def get_device_type(client: CloudvisionApi, dId: str):
     pathElts = ["Sysdb", "hardware", "entmib"]
     query = get_query(client, dId, pathElts)
     query = unfreeze_frozen_dict(query)
-    if query["fixedSystem"] is None:
+    if "fixedSystem" in query and query["fixedSystem"] is None:
         dType = "modular"
-    else:
+    elif query.get("fixedSystem"):
         dType = "fixedSystem"
+    else:
+        dType = "Unknown"
     return dType
 
 

--- a/nautobot_ssot_aristacv/utils/cloudvision.py
+++ b/nautobot_ssot_aristacv/utils/cloudvision.py
@@ -470,26 +470,23 @@ def get_interfaces_chassis(client: CloudvisionApi, dId):
 
         query = [create_query([(pathElts, [])], dataset)]
 
-        for batch in client.get(query):
-            for notif in batch["notifications"]:
+        for interface in client.get(query):
+            new_intf = {}
+            for notif in interface["notifications"]:
                 results = notif["updates"]
                 if results.get("intfId"):
-                    intfStatusChassis.append(
-                        {
-                            "interface": results["intfId"],
-                            "link_status": "up"
-                            if results.get("linkStatus") and results["linkStatus"]["Name"] == "linkUp"
-                            else "down",
-                            "oper_status": "up"
-                            if results.get("operStatus") and results["operStatus"]["Name"] == "intfOperUp"
-                            else "down",
-                            "enabled": bool(results["enabledState"]["Name"] == "enabled")
-                            if results.get("enabledState")
-                            else False,
-                            "mac_addr": results["burnedInAddr"],
-                            "mtu": results["mtu"],
-                        }
-                    )
+                    new_intf["interface"] = results["intfId"]
+                if results.get("linkStatus"):
+                    new_intf["link_status"] = results["linkStatus"]
+                if results.get("operStatus"):
+                    new_intf["oper_status"] = results["operStatus"]
+                if results.get("enabledState"):
+                    new_intf["enabled"] = bool(results["enabledState"]["Name"] == "enabled")
+                if results.get("burnedInAddr"):
+                    new_intf["mac_addr"] = results["burnedInAddr"]
+                if results.get("mtu"):
+                    new_intf["mtu"] = results["mtu"]
+            intfStatusChassis.append(new_intf)
     return intfStatusChassis
 
 

--- a/nautobot_ssot_aristacv/utils/cloudvision.py
+++ b/nautobot_ssot_aristacv/utils/cloudvision.py
@@ -477,9 +477,9 @@ def get_interfaces_chassis(client: CloudvisionApi, dId):
                 if results.get("intfId"):
                     new_intf["interface"] = results["intfId"]
                 if results.get("linkStatus"):
-                    new_intf["link_status"] = results["linkStatus"]
+                    new_intf["link_status"] = "up" if results["linkStatus"]["Name"] == "linkUp" else "down"
                 if results.get("operStatus"):
-                    new_intf["oper_status"] = results["operStatus"]
+                    new_intf["oper_status"] = "up" if results["operStatus"]["Name"] == "intfOperUp" else "down"
                 if results.get("enabledState"):
                     new_intf["enabled"] = bool(results["enabledState"]["Name"] == "enabled")
                 if results.get("burnedInAddr"):
@@ -515,9 +515,9 @@ def get_interfaces_fixed(client: CloudvisionApi, dId: str):
             if results.get("mtu"):
                 new_intf["mtu"] = results["mtu"]
             if results.get("operStatus"):
-                new_intf["oper_status"] = results["operStatus"]
+                new_intf["oper_status"] = "up" if results["operStatus"]["Name"] == "intfOperUp" else "down"
             if results.get("linkStatus"):
-                new_intf["link_status"] = results["linkStatus"]
+                new_intf["link_status"] = "up" if results["linkStatus"]["Name"] == "linkUp" else "down"
         intfStatusFixed.append(new_intf)
     return intfStatusFixed
 

--- a/nautobot_ssot_aristacv/utils/cloudvision.py
+++ b/nautobot_ssot_aristacv/utils/cloudvision.py
@@ -505,26 +505,23 @@ def get_interfaces_fixed(client: CloudvisionApi, dId: str):
     query = unfreeze_frozen_dict(query)
 
     intfStatusFixed = []
-    for batch in client.get(query):
-        for notif in batch["notifications"]:
+    for interface in client.get(query):
+        new_intf = {}
+        for notif in interface["notifications"]:
             results = notif["updates"]
             if results.get("intfId"):
-                intfStatusFixed.append(
-                    {
-                        "interface": results["intfId"],
-                        "link_status": "up"
-                        if results.get("linkStatus") and results["linkStatus"]["Name"] == "linkUp"
-                        else "down",
-                        "oper_status": "up"
-                        if results.get("operStatus") and results["operStatus"]["Name"] == "intfOperUp"
-                        else "down",
-                        "enabled": bool(
-                            results["enabledState"]["Name"] == "enabled" if results.get("enabledState") else False
-                        ),
-                        "mac_addr": results["burnedInAddr"] if results.get("burnedInAddr") else "",
-                        "mtu": results["mtu"] if results.get("mtu") else 1500,
-                    }
-                )
+                new_intf["interface"] = results["intfId"]
+            if results.get("enabledState"):
+                new_intf["enabled"] = bool(results["enabledState"]["Name"] == "enabled")
+            if results.get("burnedInAddr"):
+                new_intf["mac_addr"] = results["burnedInAddr"]
+            if results.get("mtu"):
+                new_intf["mtu"] = results["mtu"]
+            if results.get("operStatus"):
+                new_intf["oper_status"] = results["operStatus"]
+            if results.get("linkStatus"):
+                new_intf["link_status"] = results["linkStatus"]
+        intfStatusFixed.append(new_intf)
     return intfStatusFixed
 
 

--- a/nautobot_ssot_aristacv/utils/nautobot.py
+++ b/nautobot_ssot_aristacv/utils/nautobot.py
@@ -81,8 +81,14 @@ def get_device_version(device):
         software_relation = Relationship.objects.get(name="Software on Device")
         relations = device.get_relationships()
         try:
-            version = relations["destination"][software_relation][0].source.version
+            assigned_versions = relations["destination"][software_relation]
+            if len(assigned_versions) > 0:
+                version = assigned_versions[0].source.version
+            else:
+                return ""
         except KeyError:
+            pass
+        except IndexError:
             pass
     else:
         version = device.custom_field_data["arista_eos"]


### PR DESCRIPTION
During a test run in an instance with brand new Device Lifecycle plug-in integration and unassigned Software Versions to devices. This caused an IndexError exception to be thrown in the `get_device_version` method. This first checks there is an assigned version and also will now catch an IndexError and return a blank version as expected. There was also a discovery during my testing that interface Status wasn't being shown correctly as detailed in #117. I've included a fix to address that bug. Finally, there was an issue with APs connected to CVP as detailed in #116. There is also a fix for that bug included here. It's a simple check for whether the query response is blank or not and has the key. If it doesn't and we can't determine the device type, it raises a log warning about it for the user and skips processing interfaces.