### PR TITLE
Fix Hostname Parsing

### DIFF
--- a/nautobot_ssot_aristacv/tests/test_utils_nautobot.py
+++ b/nautobot_ssot_aristacv/tests/test_utils_nautobot.py
@@ -102,7 +102,15 @@ class TestNautobotUtils(TestCase):
         self.assertEqual(result, "1.0")
 
     @override_settings(
-        PLUGINS_CONFIG={"nautobot_ssot_aristacv": {"hostname_patterns": [r"(?P<site>\w{2,3}\d+)-(?P<role>\w+)-\d+"]}}
+        PLUGINS_CONFIG={
+            "nautobot_ssot_aristacv": {
+                "hostname_patterns": [r"(?P<site>\w{2,3}\d+)-(?P<role>\w+)-\d+"],
+                "site_mappings": {"ams01": "Amsterdam"},
+                "role_mappings": {
+                    "leaf": "leaf",
+                },
+            }
+        }
     )
     def test_parse_hostname(self):
         """Test the parse_hostname method."""
@@ -111,28 +119,56 @@ class TestNautobotUtils(TestCase):
         expected = ("ams01", "leaf")
         self.assertEqual(results, expected)
 
-    @override_settings(PLUGINS_CONFIG={"nautobot_ssot_aristacv": {"site_mappings": {"ams01": "Amsterdam"}}})
+    @override_settings(
+        PLUGINS_CONFIG={
+            "nautobot_ssot_aristacv": {
+                "hostname_patterns": [r"(?P<site>\w{2,3}\d+)-(?P<role>\w+)-\d+"],
+                "site_mappings": {"ams01": "Amsterdam"},
+            }
+        }
+    )
     def test_get_site_from_map_success(self):
         """Test the get_site_from_map method with response."""
         results = nautobot.get_site_from_map("ams01")
         expected = "Amsterdam"
         self.assertEqual(results, expected)
 
-    @override_settings(PLUGINS_CONFIG={"nautobot_ssot_aristacv": {"site_mappings": {}}})
+    @override_settings(
+        PLUGINS_CONFIG={
+            "nautobot_ssot_aristacv": {
+                "hostname_patterns": [r"(?P<site>\w{2,3}\d+)-(?P<role>\w+)-\d+"],
+                "site_mappings": {},
+            }
+        }
+    )
     def test_get_site_from_map_fail(self):
         """Test the get_site_from_map method with failed response."""
         results = nautobot.get_site_from_map("dc01")
         expected = None
         self.assertEqual(results, expected)
 
-    @override_settings(PLUGINS_CONFIG={"nautobot_ssot_aristacv": {"role_mappings": {"edge": "Edge Router"}}})
+    @override_settings(
+        PLUGINS_CONFIG={
+            "nautobot_ssot_aristacv": {
+                "hostname_patterns": [r"(?P<site>\w{2,3}\d+)-(?P<role>\w+)-\d+"],
+                "role_mappings": {"edge": "Edge Router"},
+            }
+        }
+    )
     def test_get_role_from_map_success(self):
         """Test the get_role_from_map method with response."""
         results = nautobot.get_role_from_map("edge")
         expected = "Edge Router"
         self.assertEqual(results, expected)
 
-    @override_settings(PLUGINS_CONFIG={"nautobot_ssot_aristacv": {"role_mappings": {}}})
+    @override_settings(
+        PLUGINS_CONFIG={
+            "nautobot_ssot_aristacv": {
+                "hostname_patterns": [r"(?P<site>\w{2,3}\d+)-(?P<role>\w+)-\d+"],
+                "role_mappings": {},
+            }
+        }
+    )
     def test_get_role_from_map_fail(self):
         """Test the get_role_from_map method with failed response."""
         results = nautobot.get_role_from_map("rtr")

--- a/nautobot_ssot_aristacv/tests/test_utils_nautobot.py
+++ b/nautobot_ssot_aristacv/tests/test_utils_nautobot.py
@@ -122,6 +122,38 @@ class TestNautobotUtils(TestCase):
     @override_settings(
         PLUGINS_CONFIG={
             "nautobot_ssot_aristacv": {
+                "hostname_patterns": [r"(?P<site>\w{2,3}\d+)-.+-\d+"],
+                "site_mappings": {"ams01": "Amsterdam"},
+                "role_mappings": {},
+            }
+        }
+    )
+    def test_parse_hostname_only_site(self):
+        """Test the parse_hostname method with only site specified."""
+        host = "ams01-leaf-01"
+        results = nautobot.parse_hostname(host)
+        expected = ("ams01", None)
+        self.assertEqual(results, expected)
+
+    @override_settings(
+        PLUGINS_CONFIG={
+            "nautobot_ssot_aristacv": {
+                "hostname_patterns": [r".+-(?P<role>\w+)-\d+"],
+                "site_mappings": {},
+                "role_mappings": {"leaf": "leaf"},
+            }
+        }
+    )
+    def test_parse_hostname_only_role(self):
+        """Test the parse_hostname method with only role specified."""
+        host = "ams01-leaf-01"
+        results = nautobot.parse_hostname(host)
+        expected = (None, "leaf")
+        self.assertEqual(results, expected)
+
+    @override_settings(
+        PLUGINS_CONFIG={
+            "nautobot_ssot_aristacv": {
                 "hostname_patterns": [r"(?P<site>\w{2,3}\d+)-(?P<role>\w+)-\d+"],
                 "site_mappings": {"ams01": "Amsterdam"},
             }

--- a/nautobot_ssot_aristacv/utils/nautobot.py
+++ b/nautobot_ssot_aristacv/utils/nautobot.py
@@ -107,9 +107,9 @@ def parse_hostname(hostname: str):
     for pattern in hostname_patterns:
         match = re.search(pattern=pattern, string=hostname)
         if match:
-            if match.group("site"):
+            if "site" in match.groupdict() and match.group("site"):
                 site = match.group("site")
-            if match.group("role"):
+            if "role" in match.groupdict() and match.group("role"):
                 role = match.group("role")
     return (site, role)
 


### PR DESCRIPTION
This PR fixes the issue that was provided in #119. I've added a check that there is indeed a named capture group called site or role when a match is found. This should ensure that there is one defined in the `hostname_patterns` setting. I've also added some unit tests to confirm functionality when defining only a site or role capture group.