### PR TITLE
fix: Correct Interface Mode

### DIFF
--- a/nautobot_ssot_aristacv/diffsync/adapters/cloudvision.py
+++ b/nautobot_ssot_aristacv/diffsync/adapters/cloudvision.py
@@ -91,8 +91,10 @@ class CloudvisionAdapter(DiffSync):
         for port in port_info:
             if self.job.kwargs.get("debug"):
                 self.job.log_debug(message=f"Port {port['interface']} being loaded for {device.name}.")
-            port_mode = cloudvision.get_interface_mode(client=self.conn, dId=device.serial, interface=port)
-            transceiver = cloudvision.get_interface_transceiver(client=self.conn, dId=device.serial, interface=port)
+            port_mode = cloudvision.get_interface_mode(client=self.conn, dId=device.serial, interface=port["interface"])
+            transceiver = cloudvision.get_interface_transceiver(
+                client=self.conn, dId=device.serial, interface=port["interface"]
+            )
             if transceiver == "Unknown":
                 # Breakout transceivers, ie 40G -> 4x10G, shows up as 4 interfaces and requires looking at base interface to find transceiver, ie Ethernet1 if Ethernet1/1
                 base_port_name = re.sub(r"/\d", "", port["interface"])

--- a/nautobot_ssot_aristacv/tests/fixtures/fixtures.py
+++ b/nautobot_ssot_aristacv/tests/fixtures/fixtures.py
@@ -22,5 +22,9 @@ CHASSIS_INTERFACE_FIXTURE = load_json("./nautobot_ssot_aristacv/tests/fixtures/g
 INTF_DESCRIPTION_QUERY = load_json(
     "./nautobot_ssot_aristacv/tests/fixtures/get_interface_description_client_query.json"
 )
+TRUNK_INTF_MODE_QUERY = load_json("./nautobot_ssot_aristacv/tests/fixtures/get_interface_mode_client_query_trunk.json")
+ACCESS_INTF_MODE_QUERY = load_json(
+    "./nautobot_ssot_aristacv/tests/fixtures/get_interface_mode_client_query_access.json"
+)
 IP_INTF_QUERY = load_json("./nautobot_ssot_aristacv/tests/fixtures/get_ip_interfaces_client_query.json")
 IP_INTF_FIXTURE = load_json("./nautobot_ssot_aristacv/tests/fixtures/get_ip_interfaces_response.json")

--- a/nautobot_ssot_aristacv/tests/fixtures/get_interface_mode_client_query_access.json
+++ b/nautobot_ssot_aristacv/tests/fixtures/get_interface_mode_client_query_access.json
@@ -1,0 +1,193 @@
+[
+    {
+        "dataset": {
+            "name": "JPE12345678",
+            "type": "device"
+        },
+        "notifications": [
+            {
+                "timestamp": {
+                    "seconds": 1666161644,
+                    "nanos": 861836218
+                },
+                "deletes": [],
+                "updates": {
+                    "name": "",
+                    "intfId": "Ethernet5",
+                    "source": "cli",
+                    "enabled": true,
+                    "version": 1,
+                    "tapGroup": [
+                        "Sysdb",
+                        "bridging",
+                        "switchIntfConfig",
+                        "switchIntfConfig",
+                        "Ethernet5",
+                        "tapGroup"
+                    ],
+                    "vlanTpid": {
+                        "value": 33024
+                    },
+                    "phoneVlan": {
+                        "value": 0
+                    },
+                    "toolGroup": [
+                        "Sysdb",
+                        "bridging",
+                        "switchIntfConfig",
+                        "switchIntfConfig",
+                        "Ethernet5",
+                        "toolGroup"
+                    ],
+                    "accessVlan": {
+                        "value": 1
+                    },
+                    "phoneTrunk": false,
+                    "tapMplsPop": false,
+                    "tapRawIntf": [
+                        "Sysdb",
+                        "bridging",
+                        "switchIntfConfig",
+                        "switchIntfConfig",
+                        "Ethernet5",
+                        "tapRawIntf"
+                    ],
+                    "trunkGroup": [
+                        "Sysdb",
+                        "bridging",
+                        "switchIntfConfig",
+                        "switchIntfConfig",
+                        "Ethernet5",
+                        "trunkGroup"
+                    ],
+                    "tapGreStrip": false,
+                    "toolBrStrip": false,
+                    "toolMplsPop": false,
+                    "toolVnStrip": false,
+                    "l2SubIntfVlan": {
+                        "vlanId": {
+                            "value": 0
+                        },
+                        "nameOrId": {
+                            "Name": "none",
+                            "Value": 0
+                        },
+                        "vlanName": ""
+                    },
+                    "tapNativeVlan": {
+                        "value": 1
+                    },
+                    "tapVxlanStrip": false,
+                    "switchportMode": {
+                        "Name": "access",
+                        "Value": 1
+                    },
+                    "egressVlanXlate": [
+                        "Sysdb",
+                        "bridging",
+                        "switchIntfConfig",
+                        "switchIntfConfig",
+                        "Ethernet5",
+                        "egressVlanXlate"
+                    ],
+                    "floodingEnabled": true,
+                    "tapAllowedVlans": "100",
+                    "trunkNativeVlan": {
+                        "value": 1
+                    },
+                    "ingressVlanXlate": [
+                        "Sysdb",
+                        "bridging",
+                        "switchIntfConfig",
+                        "switchIntfConfig",
+                        "Ethernet5",
+                        "ingressVlanXlate"
+                    ],
+                    "l3SourceportDrop": false,
+                    "toolAllowedVlans": "100",
+                    "phoneTrunkTagMode": {
+                        "Name": "notSet",
+                        "Value": 0
+                    },
+                    "tapTruncationSize": 0,
+                    "trunkAllowedVlans": "",
+                    "vlanTagFormatDrop": [
+                        "Sysdb",
+                        "bridging",
+                        "switchIntfConfig",
+                        "switchIntfConfig",
+                        "Ethernet5",
+                        "vlanTagFormatDrop"
+                    ],
+                    "macLearningEnabled": true,
+                    "privateVlanMapping": [
+                        "Sysdb",
+                        "bridging",
+                        "switchIntfConfig",
+                        "switchIntfConfig",
+                        "Ethernet5",
+                        "privateVlanMapping"
+                    ],
+                    "toolTruncationSize": 0,
+                    "vlanForwardingMode": {
+                        "Name": "vlanForwardingModeAllowedVlansOnPort",
+                        "Value": 0
+                    },
+                    "blockUnknownUnicast": false,
+                    "tapAllowedGreTunnel": [
+                        "Sysdb",
+                        "bridging",
+                        "switchIntfConfig",
+                        "switchIntfConfig",
+                        "Ethernet5",
+                        "tapAllowedGreTunnel"
+                    ],
+                    "toolIdentityTagging": {
+                        "Name": "none",
+                        "Value": 0
+                    },
+                    "vlanMappingRequired": [
+                        "Sysdb",
+                        "bridging",
+                        "switchIntfConfig",
+                        "switchIntfConfig",
+                        "Ethernet5",
+                        "vlanMappingRequired"
+                    ],
+                    "sourceportFilterMode": {
+                        "Name": "sourceportFilterEnabled",
+                        "Value": 1
+                    },
+                    "toolDot1qRemoveVlans": "",
+                    "blockUnknownMulticast": false,
+                    "egressNativeVlanXlate": {
+                        "value": 0
+                    },
+                    "tapIdentificationVlan": {
+                        "innerVid": {
+                            "value": 0
+                        },
+                        "outerVid": {
+                            "value": 0
+                        }
+                    },
+                    "ingressNativeVlanXlate": {
+                        "value": 0
+                    },
+                    "accessVlanEgressEnabled": false,
+                    "nativeVlanEgressEnabled": false,
+                    "trunkPrivateVlanMapping": false,
+                    "defaultPrivateVlanMapping": true
+                },
+                "retracts": [],
+                "path_elements": [
+                    "Sysdb",
+                    "bridging",
+                    "switchIntfConfig",
+                    "switchIntfConfig",
+                    "Ethernet5"
+                ]
+            }
+        ]
+    }
+]

--- a/nautobot_ssot_aristacv/tests/fixtures/get_interface_mode_client_query_trunk.json
+++ b/nautobot_ssot_aristacv/tests/fixtures/get_interface_mode_client_query_trunk.json
@@ -1,0 +1,193 @@
+[
+    {
+        "dataset": {
+            "name": "JPE12345678",
+            "type": "device"
+        },
+        "notifications": [
+            {
+                "timestamp": {
+                    "seconds": 1666161644,
+                    "nanos": 861836218
+                },
+                "deletes": [],
+                "updates": {
+                    "name": "",
+                    "intfId": "Ethernet1",
+                    "source": "cli",
+                    "enabled": true,
+                    "version": 1,
+                    "tapGroup": [
+                        "Sysdb",
+                        "bridging",
+                        "switchIntfConfig",
+                        "switchIntfConfig",
+                        "Ethernet1",
+                        "tapGroup"
+                    ],
+                    "vlanTpid": {
+                        "value": 33024
+                    },
+                    "phoneVlan": {
+                        "value": 0
+                    },
+                    "toolGroup": [
+                        "Sysdb",
+                        "bridging",
+                        "switchIntfConfig",
+                        "switchIntfConfig",
+                        "Ethernet1",
+                        "toolGroup"
+                    ],
+                    "accessVlan": {
+                        "value": 1
+                    },
+                    "phoneTrunk": false,
+                    "tapMplsPop": false,
+                    "tapRawIntf": [
+                        "Sysdb",
+                        "bridging",
+                        "switchIntfConfig",
+                        "switchIntfConfig",
+                        "Ethernet1",
+                        "tapRawIntf"
+                    ],
+                    "trunkGroup": [
+                        "Sysdb",
+                        "bridging",
+                        "switchIntfConfig",
+                        "switchIntfConfig",
+                        "Ethernet1",
+                        "trunkGroup"
+                    ],
+                    "tapGreStrip": false,
+                    "toolBrStrip": false,
+                    "toolMplsPop": false,
+                    "toolVnStrip": false,
+                    "l2SubIntfVlan": {
+                        "vlanId": {
+                            "value": 0
+                        },
+                        "nameOrId": {
+                            "Name": "none",
+                            "Value": 0
+                        },
+                        "vlanName": ""
+                    },
+                    "tapNativeVlan": {
+                        "value": 1
+                    },
+                    "tapVxlanStrip": false,
+                    "switchportMode": {
+                        "Name": "trunk",
+                        "Value": 1
+                    },
+                    "egressVlanXlate": [
+                        "Sysdb",
+                        "bridging",
+                        "switchIntfConfig",
+                        "switchIntfConfig",
+                        "Ethernet1",
+                        "egressVlanXlate"
+                    ],
+                    "floodingEnabled": true,
+                    "tapAllowedVlans": "1-4095",
+                    "trunkNativeVlan": {
+                        "value": 1
+                    },
+                    "ingressVlanXlate": [
+                        "Sysdb",
+                        "bridging",
+                        "switchIntfConfig",
+                        "switchIntfConfig",
+                        "Ethernet1",
+                        "ingressVlanXlate"
+                    ],
+                    "l3SourceportDrop": false,
+                    "toolAllowedVlans": "1-4095",
+                    "phoneTrunkTagMode": {
+                        "Name": "notSet",
+                        "Value": 0
+                    },
+                    "tapTruncationSize": 0,
+                    "trunkAllowedVlans": "3802,3806,3808,3810,3831,3833",
+                    "vlanTagFormatDrop": [
+                        "Sysdb",
+                        "bridging",
+                        "switchIntfConfig",
+                        "switchIntfConfig",
+                        "Ethernet1",
+                        "vlanTagFormatDrop"
+                    ],
+                    "macLearningEnabled": true,
+                    "privateVlanMapping": [
+                        "Sysdb",
+                        "bridging",
+                        "switchIntfConfig",
+                        "switchIntfConfig",
+                        "Ethernet1",
+                        "privateVlanMapping"
+                    ],
+                    "toolTruncationSize": 0,
+                    "vlanForwardingMode": {
+                        "Name": "vlanForwardingModeAllowedVlansOnPort",
+                        "Value": 0
+                    },
+                    "blockUnknownUnicast": false,
+                    "tapAllowedGreTunnel": [
+                        "Sysdb",
+                        "bridging",
+                        "switchIntfConfig",
+                        "switchIntfConfig",
+                        "Ethernet1",
+                        "tapAllowedGreTunnel"
+                    ],
+                    "toolIdentityTagging": {
+                        "Name": "none",
+                        "Value": 0
+                    },
+                    "vlanMappingRequired": [
+                        "Sysdb",
+                        "bridging",
+                        "switchIntfConfig",
+                        "switchIntfConfig",
+                        "Ethernet1",
+                        "vlanMappingRequired"
+                    ],
+                    "sourceportFilterMode": {
+                        "Name": "sourceportFilterEnabled",
+                        "Value": 1
+                    },
+                    "toolDot1qRemoveVlans": "",
+                    "blockUnknownMulticast": false,
+                    "egressNativeVlanXlate": {
+                        "value": 0
+                    },
+                    "tapIdentificationVlan": {
+                        "innerVid": {
+                            "value": 0
+                        },
+                        "outerVid": {
+                            "value": 0
+                        }
+                    },
+                    "ingressNativeVlanXlate": {
+                        "value": 0
+                    },
+                    "accessVlanEgressEnabled": false,
+                    "nativeVlanEgressEnabled": false,
+                    "trunkPrivateVlanMapping": false,
+                    "defaultPrivateVlanMapping": true
+                },
+                "retracts": [],
+                "path_elements": [
+                    "Sysdb",
+                    "bridging",
+                    "switchIntfConfig",
+                    "switchIntfConfig",
+                    "Ethernet1"
+                ]
+            }
+        ]
+    }
+]

--- a/nautobot_ssot_aristacv/tests/test_utils_cloudvision.py
+++ b/nautobot_ssot_aristacv/tests/test_utils_cloudvision.py
@@ -263,6 +263,46 @@ class TestCloudvisionUtils(TestCase):
             )
         self.assertEqual(results, "xcvr1000BaseT")
 
+    def test_get_interface_mode_trunk(self):
+        """Test the get_interface_mode method for a trunk."""
+        mock_query = MagicMock()
+        mock_query.dataset.type = "device"
+        mock_query.dataset.name = "JPE12345678"
+        mock_query.paths.path_elements = [
+            "\304\005Sysdb",
+            "\304\010bridging",
+            "\304\020switchIntfConfig",
+            "\304\020switchIntfConfig",
+            "\304\tEthernet1",
+        ]
+
+        with patch("cloudvision.Connector.grpc_client.grpcClient.create_query", mock_query):
+            self.client.get = MagicMock()
+            self.client.get.return_value = fixtures.TRUNK_INTF_MODE_QUERY
+            results = cloudvision.get_interface_mode(client=self.client, dId="JPE12345678", interface="Ethernet1")
+        expected = "trunk"
+        self.assertEqual(results, expected)
+
+    def test_get_interface_mode_access(self):
+        """Test the get_interface_mode method for a access."""
+        mock_query = MagicMock()
+        mock_query.dataset.type = "device"
+        mock_query.dataset.name = "JPE12345678"
+        mock_query.paths.path_elements = [
+            "\304\005Sysdb",
+            "\304\010bridging",
+            "\304\020switchIntfConfig",
+            "\304\020switchIntfConfig",
+            "\304\tEthernet5",
+        ]
+
+        with patch("cloudvision.Connector.grpc_client.grpcClient.create_query", mock_query):
+            self.client.get = MagicMock()
+            self.client.get.return_value = fixtures.ACCESS_INTF_MODE_QUERY
+            results = cloudvision.get_interface_mode(client=self.client, dId="JPE12345678", interface="Ethernet5")
+        expected = "access"
+        self.assertEqual(results, expected)
+
     port_types = [
         ("built_in_gig", {"port_info": {}, "transceiver": "xcvr1000BaseT"}, "1000base-t"),
         ("build_in_10g_sr", {"port_info": {}, "transceiver": "xcvr10GBaseSr"}, "10gbase-x-xfp"),

--- a/nautobot_ssot_aristacv/tests/test_utils_cloudvision.py
+++ b/nautobot_ssot_aristacv/tests/test_utils_cloudvision.py
@@ -194,7 +194,6 @@ class TestCloudvisionUtils(TestCase):
 
     def test_get_interfaces_chassis(self):
         """Test get_interfaces_chassis method."""
-        self.maxDiff = None  # pylint:disable=invalid-name
         mock_query = MagicMock()
         mock_query.dataset.type = "device"
         mock_query.dataset.name = "JPE12345678"


### PR DESCRIPTION
This PR includes a fix for #139. The interface name wasn't being passed to the query correctly thus causing the client response to be wrong. I've also added some unit tests representing what I've seen in the client query response and confirming that the portion of the response is returned denoting an access or trunk port.