### PR TITLE
Updated fix for the get device tags function

### DIFF
--- a/nautobot_ssot_aristacv/tests/test_utils_cloudvision.py
+++ b/nautobot_ssot_aristacv/tests/test_utils_cloudvision.py
@@ -123,7 +123,7 @@ class TestCloudvisionUtils(TestCase):
         mock_tag.value.device_id.value = "JPE12345678"
 
         tag_stub = MagicMock()
-        tag_stub.TagAssignmentConfigServiceStub.return_value.GetAll.return_value = [mock_tag]
+        tag_stub.TagAssignmentServiceStub.return_value.GetAll.return_value = [mock_tag]
 
         with patch("nautobot_ssot_aristacv.utils.cloudvision.tag_services", tag_stub):
             results = cloudvision.get_device_tags(client=self.client, device_id="JPE12345678")

--- a/nautobot_ssot_aristacv/utils/cloudvision.py
+++ b/nautobot_ssot_aristacv/utils/cloudvision.py
@@ -308,12 +308,14 @@ def get_tags_by_type(client, creator_type: int = tag_models.CREATOR_TYPE_USER):
 
 def get_device_tags(client, device_id: str):
     """Get tags for specific device."""
-    tag_stub = tag_services.TagAssignmentConfigServiceStub(client)
+    tag_stub = tag_services.TagAssignmentServiceStub(client)
     req = tag_services.TagAssignmentConfigStreamRequest(
         partial_eq_filter=[
             tag_models.TagAssignmentConfig(
                 key=tag_models.TagAssignmentKey(
                     device_id=StringValue(value=device_id),
+                    element_type=tag_models.ELEMENT_TYPE_DEVICE,
+                    workspace_id=StringValue(value=""),
                 )
             )
         ]


### PR DESCRIPTION
This PR is to fix the [issue](https://github.com/nautobot/nautobot-plugin-ssot-arista-cloudvision/issues/159) with retrieving tags with tag.v2. Arista support confirmed that the path `TagAssignmentConfigService` will only return user-assigned tags and will not return system-assigned device tags. I have swapped this to use the path `TagAssignmentService`.

workspace_id is the ID of a workspace. The special ID "" identifies the location where merged assignments reside.

From the documentation

> TagAssignment holds a merge-preview or the existing merged state (if the workspace ID is “”) of an assignment between a tag and a network element.

https://aristanetworks.github.io/cloudvision-apis/models/tag.v2/#arista.tag.v2.TagAssignmentService 